### PR TITLE
Serve built React `dist` when `HARNESS_DEBUG=false`, keep Vite proxy in debug

### DIFF
--- a/DOCS/frontend-guide.md
+++ b/DOCS/frontend-guide.md
@@ -143,4 +143,16 @@ cd react
 npm run build
 ```
 
-Output goes to `react/dist/`. The FastAPI proxy will serve these static files instead of forwarding to Vite when `HARNESS_DEBUG=false`.
+Output goes to `react/dist/`.
+
+Runtime behavior is controlled by `HARNESS_DEBUG`:
+
+- `HARNESS_DEBUG=true` (default): `/ui/*` routes proxy to the Vite dev server.
+- `HARNESS_DEBUG=false`: `/ui/*` routes serve prebuilt files from `react/dist`:
+  - `/ui/root` and `/ui/root/*` resolve to `react/dist/root.html` (or a matching static file if present).
+  - `/ui/<component_id>` and `/ui/<component_id>/*` resolve to `react/dist/<component_id>.html` (or a matching static file if present).
+  - `/assets/*` is served directly from `react/dist/assets`.
+
+In both modes, HTML responses still pass through `inject_harness_vars(...)` before being returned.
+
+If `react/dist` (or required entry HTML files) is missing in static mode, the backend returns clear `503` diagnostics instructing you to rebuild (`cd react && npm run build`) or re-enable debug mode.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HARNESS — Architecture README
 
-A native binary harness where Python components run logic/state/events and pair 1:1 with React UI apps served dynamically from a shared Vite dev server. Components run as mini-apps inside a resizable root window. Python is the brain. React is the face.
+A native binary harness where Python components run logic/state/events and pair 1:1 with React UI apps. In debug, UI is served through a shared Vite dev server; in production/static mode, UI is served from prebuilt `react/dist` files. Components run as mini-apps inside a resizable root window. Python is the brain. React is the face.
 
 > **Current implementation note:** the repository currently has a chat-first
 > root dashboard with DSPy, pipeline, tools, settings, and generated-view panels.
@@ -196,7 +196,8 @@ Dynamic Routes (registered on component mount):
 
 UI Serving:
   GET  /ui/{component_id}/{*react_routes}
-       → FastAPI proxies Vite dev server
+       → If HARNESS_DEBUG=true: FastAPI proxies Vite dev server
+       → If HARNESS_DEBUG=false: FastAPI serves files from react/dist
        → Injects into <head>:
            window.__HARNESS__ = {
              COMPONENT_ID: "{id}",
@@ -206,6 +207,16 @@ UI Serving:
              PERMISSIONS: [...]
            }
 ```
+
+### Frontend serving mode (`HARNESS_DEBUG`)
+
+- `HARNESS_DEBUG=true` (default): `/ui/*` routes proxy to Vite (`localhost:5173`) for HMR/dev workflows.
+- `HARNESS_DEBUG=false`: `/ui/*` routes serve static build artifacts from `react/dist`:
+  - `/ui/root` → `react/dist/root.html`
+  - `/ui/<component_id>` → `react/dist/<component_id>.html`
+  - `/assets/*` → `react/dist/assets/*`
+
+In both modes, HTML responses are processed by `inject_harness_vars(...)` before being returned so runtime component metadata is always available.
 
 -----
 

--- a/harness/server/app.py
+++ b/harness/server/app.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, AsyncIterator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 from harness.server.routes import components, proxy, ws
 from harness.server.routes.agent_routes import router as agent_router
@@ -137,6 +138,15 @@ def create_app(main_process: "MainProcess", settings: "HarnessSettings") -> Fast
     # Attach shared state available before lifespan (settings, main_process)
     app.state.main_process = main_process
     app.state.settings = settings
+    app.state.react_dist_dir = Path(__file__).resolve().parents[2] / "react" / "dist"
+
+    # In production/static mode, serve built frontend assets directly.
+    if not settings.harness_debug:
+        app.mount(
+            "/assets",
+            StaticFiles(directory=app.state.react_dist_dir / "assets", check_dir=False),
+            name="ui-assets",
+        )
 
     # ── Routers ───────────────────────────────────────────────────────────────
     app.include_router(components.router)

--- a/harness/server/routes/proxy.py
+++ b/harness/server/routes/proxy.py
@@ -1,16 +1,19 @@
-"""Vite proxy — /ui/{component_id}/{*path} forwards to Vite dev server and injects env vars.
+"""UI serving routes for debug (Vite proxy) and static (react/dist) modes.
 
-The special-cased ``/ui/root`` route serves the main dashboard (react/index.html) without
-requiring a legacy component registration.  All Vite asset paths (``/src/…``, ``/@vite/…``,
-``/@react-refresh``, ``/node_modules/…``) are also forwarded so the browser can load the
-React app's JS/CSS from the FastAPI origin.
+`HARNESS_DEBUG=true`:
+    /ui/* is proxied to Vite and HTML is injected with harness vars.
+`HARNESS_DEBUG=false`:
+    /ui/* is resolved from react/dist (entry HTML + static assets), with the same
+    harness var injection on HTML responses.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, Response
 
 from harness.server.injector import inject_harness_vars
 
@@ -32,6 +35,75 @@ async def _proxy_to_vite(path: str, vite_url: str) -> Response:
     return Response(content=resp.content, status_code=resp.status_code, headers=headers)
 
 
+def _dist_root(request: Request) -> Path:
+    return request.app.state.react_dist_dir
+
+
+def _ensure_dist_available(dist_dir: Path) -> None:
+    if not dist_dir.exists() or not dist_dir.is_dir():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Static UI build is unavailable: missing react/dist. "
+                "Run `cd react && npm run build` or set HARNESS_DEBUG=true."
+            ),
+        )
+
+
+def _safe_dist_file(dist_dir: Path, relative_path: str) -> Path | None:
+    candidate = (dist_dir / relative_path).resolve()
+    try:
+        candidate.relative_to(dist_dir.resolve())
+    except ValueError:
+        return None
+    if not candidate.is_file():
+        return None
+    return candidate
+
+
+def _inject_html_from_dist(
+    *,
+    request: Request,
+    entry_file: str,
+    component_id: str,
+    initial_state: dict,
+    permissions: list[str],
+) -> HTMLResponse:
+    settings = request.app.state.settings
+    dist_dir = _dist_root(request)
+    _ensure_dist_available(dist_dir)
+    html_file = dist_dir / entry_file
+
+    if not html_file.exists():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"Static UI entry is unavailable: missing {entry_file} in react/dist. "
+                "Rebuild frontend (`cd react && npm run build`) or set HARNESS_DEBUG=true."
+            ),
+        )
+
+    try:
+        raw_html = html_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to read static UI entry {entry_file}: {exc}",
+        ) from exc
+
+    api_base = f"http://{settings.harness_host}:{settings.harness_port}"
+    ws_base = f"ws://{settings.harness_host}:{settings.harness_port}"
+    html = inject_harness_vars(
+        html=raw_html,
+        component_id=component_id,
+        api_base=api_base,
+        ws_base=ws_base,
+        initial_state=initial_state,
+        permissions=permissions,
+    )
+    return HTMLResponse(content=html, status_code=200)
+
+
 # ── Root dashboard (special-cased — not a legacy component) ──────────────────
 
 @router.get("/ui/root")
@@ -39,6 +111,23 @@ async def _proxy_to_vite(path: str, vite_url: str) -> Response:
 async def serve_root_ui(request: Request, path: str = "") -> Response:
     """Serve the main VLoop Harness dashboard from react/index.html."""
     settings = request.app.state.settings
+    if not settings.harness_debug:
+        dist_dir = _dist_root(request)
+        _ensure_dist_available(dist_dir)
+
+        if path:
+            static_file = _safe_dist_file(dist_dir, path)
+            if static_file is not None:
+                return FileResponse(static_file)
+
+        return _inject_html_from_dist(
+            request=request,
+            entry_file="root.html",
+            component_id="root",
+            initial_state={},
+            permissions=[],
+        )
+
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
 
     # Non-HTML sub-paths (e.g. HMR WebSocket upgrade requests) go straight to Vite.
@@ -73,6 +162,8 @@ async def serve_root_ui(request: Request, path: str = "") -> Response:
 @router.get("/src/{path:path}")
 async def vite_src(path: str, request: Request) -> Response:
     settings = request.app.state.settings
+    if not settings.harness_debug:
+        raise HTTPException(status_code=404, detail="Route unavailable outside debug mode")
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
     return await _proxy_to_vite(f"src/{path}", vite_url)
 
@@ -80,6 +171,8 @@ async def vite_src(path: str, request: Request) -> Response:
 @router.get("/@{path:path}")
 async def vite_internal(path: str, request: Request) -> Response:
     settings = request.app.state.settings
+    if not settings.harness_debug:
+        raise HTTPException(status_code=404, detail="Route unavailable outside debug mode")
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
     return await _proxy_to_vite(f"@{path}", vite_url)
 
@@ -87,6 +180,8 @@ async def vite_internal(path: str, request: Request) -> Response:
 @router.get("/node_modules/{path:path}")
 async def vite_node_modules(path: str, request: Request) -> Response:
     settings = request.app.state.settings
+    if not settings.harness_debug:
+        raise HTTPException(status_code=404, detail="Route unavailable outside debug mode")
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
     return await _proxy_to_vite(f"node_modules/{path}", vite_url)
 
@@ -106,6 +201,24 @@ async def serve_component_ui(
 
     if comp is None:
         raise HTTPException(status_code=404, detail="Component not found")
+
+    if not settings.harness_debug:
+        dist_dir = _dist_root(request)
+        _ensure_dist_available(dist_dir)
+
+        if path:
+            static_file = _safe_dist_file(dist_dir, path)
+            if static_file is not None:
+                return FileResponse(static_file)
+
+        perms = [p.value for p in comp.permissions.all_granted()]
+        return _inject_html_from_dist(
+            request=request,
+            entry_file=f"{component_id}.html",
+            component_id=component_id,
+            initial_state=comp.state,
+            permissions=perms,
+        )
 
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
     vite_path = f"src/components/{component_id}/index.html" if not path else path


### PR DESCRIPTION
### Motivation
- Allow the harness to serve a production/static React build from `react/dist` when Vite is not available, while preserving the existing Vite proxy behavior for development.
- Provide clear diagnostics when the static build is missing and ensure HTML responses still receive the runtime `window.__HARNESS__` injection.

### Description
- Added dual-mode UI routing in `harness/server/routes/proxy.py` that branches on `settings.harness_debug`: when true the code keeps proxying requests to the Vite dev server, and when false it serves files from `react/dist` (including entry HTML files) with the same harness var injection for HTML responses.
- Implemented helpers in `proxy.py` for locating `react/dist` (`_dist_root`), validating availability (`_ensure_dist_available`), safely resolving static files (`_safe_dist_file`), and injecting harness vars into built HTML (`_inject_html_from_dist`), and return `503`/`500` diagnostics when `dist` or entry files are missing or unreadable.
- Updated `harness/server/app.py` to attach `app.state.react_dist_dir` and to mount `/assets` from `react/dist/assets` when `HARNESS_DEBUG=false` so static assets can be served efficiently.
- Updated docs in `DOCS/frontend-guide.md` and `README.md` to describe the runtime behavior controlled by `HARNESS_DEBUG` and the mapping of routes to `react/dist` files (e.g. `root.html`, `<component_id>.html`, and `/assets`).

### Testing
- Ran bytecode compilation with `python -m compileall harness/server/routes/proxy.py harness/server/app.py harness/settings.py`, which succeeded.
- Attempted to run `pytest -q tests/test_injector.py tests/test_views_routes.py`, but the run failed in this environment due to a missing test dependency (`pytest_asyncio`), so unit tests were not executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecdfec0d04832aaa6a308209d66cac)