### PR TITLE
Stable UI mounts for generated views and app manifests

### DIFF
--- a/harness/data/repository.py
+++ b/harness/data/repository.py
@@ -235,6 +235,22 @@ class Repository:
     async def get_view(self, view_id: str) -> GeneratedView | None:
         return await self.session.get(GeneratedView, view_id)
 
+    async def get_view_by_component_name(self, component_name: str) -> GeneratedView | None:
+        result = await self.session.execute(
+            select(GeneratedView)
+            .where(GeneratedView.component_name == component_name)
+            .order_by(GeneratedView.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def resolve_view_ref(self, view_ref: str) -> GeneratedView | None:
+        """Resolve a view ref stored in manifests (view id OR component_name)."""
+        view = await self.get_view(view_ref)
+        if view is not None:
+            return view
+        return await self.get_view_by_component_name(view_ref)
+
     async def delete_view(self, view_id: str) -> None:
         v = await self.session.get(GeneratedView, view_id)
         if v:

--- a/harness/server/routes/app_routes.py
+++ b/harness/server/routes/app_routes.py
@@ -199,6 +199,56 @@ async def delete_manifest(
     await repo.delete_app_manifest(manifest_id)
 
 
+@router.get("/manifests/{manifest_id}/launch")
+async def launch_manifest(
+    manifest_id: str,
+    db: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    repo = Repository(db)
+    manifest = await repo.get_app_manifest(manifest_id)
+    if manifest is None:
+        raise HTTPException(status_code=404, detail="App manifest not found")
+
+    if not manifest.react_views:
+        raise HTTPException(
+            status_code=404,
+            detail="App manifest has no linked React views",
+        )
+
+    first_ref = manifest.react_views[0]
+    view = await repo.resolve_view_ref(first_ref)
+    if view is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Linked view {first_ref!r} not found for app manifest",
+        )
+
+    return {
+        "target_type": "manifest",
+        "manifest_id": manifest.id,
+        "view_id": view.id,
+        "component_name": view.component_name,
+        "mount_url": f"/ui/apps/{manifest.id}",
+    }
+
+
+@router.get("/views/{view_ref}/launch")
+async def launch_view(
+    view_ref: str,
+    db: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    repo = Repository(db)
+    view = await repo.resolve_view_ref(view_ref)
+    if view is None:
+        raise HTTPException(status_code=404, detail="Generated view not found")
+    return {
+        "target_type": "view",
+        "view_id": view.id,
+        "component_name": view.component_name,
+        "mount_url": f"/ui/views/{view.id}",
+    }
+
+
 # ── Tool traces ───────────────────────────────────────────────────────────────
 
 

--- a/harness/server/routes/proxy.py
+++ b/harness/server/routes/proxy.py
@@ -1,17 +1,24 @@
-"""Vite proxy — /ui/{component_id}/{*path} forwards to Vite dev server and injects env vars.
+"""UI mounting proxy routes.
 
-The special-cased ``/ui/root`` route serves the main dashboard (react/index.html) without
-requiring a legacy component registration.  All Vite asset paths (``/src/…``, ``/@vite/…``,
-``/@react-refresh``, ``/node_modules/…``) are also forwarded so the browser can load the
-React app's JS/CSS from the FastAPI origin.
+Supports:
+  - Root dashboard mount (`/ui/root`) via Vite dev server.
+  - Stable generated-view mounts (`/ui/views/{view_ref}`).
+  - Stable app-manifest mounts (`/ui/apps/{manifest_id}`).
+  - Legacy component mounts (`/ui/{component_id}`).
 """
 
 from __future__ import annotations
 
-import httpx
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse, Response
+import json
+from pathlib import Path
 
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from harness.data.db import get_session
+from harness.data.repository import Repository
 from harness.server.injector import inject_harness_vars
 
 router = APIRouter()
@@ -30,6 +37,87 @@ async def _proxy_to_vite(path: str, vite_url: str) -> Response:
         if k.lower() not in ("content-encoding", "transfer-encoding", "content-length")
     }
     return Response(content=resp.content, status_code=resp.status_code, headers=headers)
+
+
+def _render_shell_html(
+    *,
+    request: Request,
+    component_id: str,
+    module_src: str,
+    css_hrefs: list[str] | None = None,
+    initial_state: dict[str, object] | None = None,
+    permissions: list[str] | None = None,
+) -> HTMLResponse:
+    settings = request.app.state.settings
+    api_base = f"http://{settings.harness_host}:{settings.harness_port}"
+    ws_base = f"ws://{settings.harness_host}:{settings.harness_port}"
+    css_tags = "\n".join(f'<link rel="stylesheet" href="{href}" />' for href in (css_hrefs or []))
+    shell = (
+        "<!doctype html><html><head><meta charset=\"UTF-8\" />"
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />"
+        f"{css_tags}"
+        "</head><body><div id=\"root\"></div>"
+        f"<script type=\"module\" src=\"{module_src}\"></script>"
+        "</body></html>"
+    )
+    html = inject_harness_vars(
+        html=shell,
+        component_id=component_id,
+        api_base=api_base,
+        ws_base=ws_base,
+        initial_state=initial_state or {},
+        permissions=permissions or [],
+    )
+    return HTMLResponse(content=html, status_code=200)
+
+
+def _react_project_dir(request: Request) -> Path:
+    storage = request.app.state.vloop_storage
+    return storage.project_dir.parent / "react"
+
+
+def _load_vite_manifest(react_dir: Path) -> dict[str, object]:
+    manifest_path = react_dir / "dist" / ".vite" / "manifest.json"
+    if not manifest_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail="Built UI assets not found. Run frontend build to serve static manifests/views.",
+        )
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Invalid Vite manifest.json") from exc
+
+
+def _resolve_dist_entry(
+    *,
+    react_dir: Path,
+    entry_key: str,
+) -> tuple[str, list[str]]:
+    manifest = _load_vite_manifest(react_dir)
+    entry = manifest.get(entry_key)
+    if not isinstance(entry, dict):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Built entry missing for {entry_key}. Rebuild the frontend.",
+        )
+    js_file = entry.get("file")
+    if not isinstance(js_file, str):
+        raise HTTPException(status_code=500, detail=f"Invalid built entry metadata for {entry_key}")
+    css = entry.get("css")
+    css_files = [f"/dist/{item}" for item in css] if isinstance(css, list) else []
+    return f"/dist/{js_file}", css_files
+
+
+async def _resolve_view_component_name(
+    view_ref: str,
+    db: AsyncSession,
+) -> tuple[str, str]:
+    repo = Repository(db)
+    view = await repo.resolve_view_ref(view_ref)
+    if view is None:
+        raise HTTPException(status_code=404, detail="Generated view not found")
+    return view.id, view.component_name
 
 
 # ── Root dashboard (special-cased — not a legacy component) ──────────────────
@@ -89,6 +177,86 @@ async def vite_node_modules(path: str, request: Request) -> Response:
     settings = request.app.state.settings
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
     return await _proxy_to_vite(f"node_modules/{path}", vite_url)
+
+
+@router.get("/dist/{path:path}")
+async def static_dist_assets(path: str, request: Request) -> Response:
+    react_dir = _react_project_dir(request)
+    asset_path = react_dir / "dist" / path
+    if not asset_path.exists() or not asset_path.is_file():
+        raise HTTPException(status_code=404, detail="Static asset not found")
+    return FileResponse(asset_path)
+
+
+# ── Stable generated UI mounts ──────────────────────────────────────────────
+
+@router.get("/ui/views/{view_ref}")
+@router.get("/ui/views/{view_ref}/{path:path}")
+async def serve_view_ui(
+    view_ref: str,
+    request: Request,
+    db: AsyncSession = Depends(get_session),
+    path: str = "",
+) -> Response:
+    _ = path  # client-side routing only; shell mount is stable for all sub-paths
+    view_id, component_name = await _resolve_view_component_name(view_ref, db)
+    settings = request.app.state.settings
+
+    entry_key = f"src/components/generated/{component_name}/main.tsx"
+    if settings.harness_debug:
+        return _render_shell_html(
+            request=request,
+            component_id=f"view:{view_id}",
+            module_src=f"/{entry_key}",
+        )
+
+    js_src, css_hrefs = _resolve_dist_entry(react_dir=_react_project_dir(request), entry_key=entry_key)
+    return _render_shell_html(
+        request=request,
+        component_id=f"view:{view_id}",
+        module_src=js_src,
+        css_hrefs=css_hrefs,
+    )
+
+
+@router.get("/ui/apps/{manifest_id}")
+@router.get("/ui/apps/{manifest_id}/{path:path}")
+async def serve_manifest_ui(
+    manifest_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_session),
+    path: str = "",
+) -> Response:
+    _ = path
+    repo = Repository(db)
+    manifest = await repo.get_app_manifest(manifest_id)
+    if manifest is None:
+        raise HTTPException(status_code=404, detail="App manifest not found")
+    if not manifest.react_views:
+        raise HTTPException(status_code=404, detail="App manifest has no linked React views")
+
+    view = await repo.resolve_view_ref(manifest.react_views[0])
+    if view is None:
+        raise HTTPException(status_code=404, detail="Manifest linked view not found")
+
+    entry_key = f"src/components/generated/{view.component_name}/main.tsx"
+    settings = request.app.state.settings
+    if settings.harness_debug:
+        return _render_shell_html(
+            request=request,
+            component_id=f"app:{manifest.id}",
+            module_src=f"/{entry_key}",
+            permissions=manifest.permissions,
+        )
+
+    js_src, css_hrefs = _resolve_dist_entry(react_dir=_react_project_dir(request), entry_key=entry_key)
+    return _render_shell_html(
+        request=request,
+        component_id=f"app:{manifest.id}",
+        module_src=js_src,
+        css_hrefs=css_hrefs,
+        permissions=manifest.permissions,
+    )
 
 
 # ── Legacy component UI ───────────────────────────────────────────────────────

--- a/react/src/components/root/AppManifestPanel.tsx
+++ b/react/src/components/root/AppManifestPanel.tsx
@@ -63,6 +63,7 @@ export default function AppManifestPanel({ focusManifestId, onFocused }: Props) 
   const [backendType, setBackendType] = useState("pipeline");
   const [backendId, setBackendId] = useState("");
   const [saving, setSaving] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -113,6 +114,17 @@ export default function AppManifestPanel({ focusManifestId, onFocused }: Props) 
   const handleDelete = async (id: string) => {
     await api.deleteAppManifest(id);
     setManifests((prev) => prev.filter((m) => m.id !== id));
+  };
+
+  const handleOpenManifest = async (manifest: AppManifest) => {
+    setLaunchError(null);
+    try {
+      const launch = await api.getAppManifestLaunch(manifest.id);
+      window.open(launch.mount_url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unable to open app manifest UI";
+      setLaunchError(msg);
+    }
   };
 
   return (
@@ -183,6 +195,11 @@ export default function AppManifestPanel({ focusManifestId, onFocused }: Props) 
 
       {/* Manifest list */}
       <Box sx={{ flexGrow: 1, overflowY: "auto" }}>
+        {launchError && (
+          <Typography variant="caption" color="error" sx={{ px: 1.5, py: 0.75, display: "block" }}>
+            {launchError}
+          </Typography>
+        )}
         {manifests.length === 0 && !loading && (
           <Typography variant="caption" color="text.secondary" sx={{ p: 2, display: "block" }}>
             No app manifests yet. Click + to create one.
@@ -222,10 +239,7 @@ export default function AppManifestPanel({ focusManifestId, onFocused }: Props) 
                   <Tooltip title="Open first view">
                     <IconButton
                       size="small"
-                      component="a"
-                      href={`/ui/${m.react_views[0]}`}
-                      target="_blank"
-                      rel="noopener"
+                      onClick={() => handleOpenManifest(m)}
                     >
                       <OpenInNewIcon fontSize="small" />
                     </IconButton>

--- a/react/src/components/root/ChatPanel.tsx
+++ b/react/src/components/root/ChatPanel.tsx
@@ -220,7 +220,7 @@ export default function ChatPanel({ focusSessionId, onFocused, onOpenPanel, onOp
       api.listMessages(activeId).then(setMessages);
     }
     onOpenPanel?.("view", view.id);
-    onOpenWorkspace?.("/ui/" + view.component_name, view.component_name);
+    onOpenWorkspace?.(`/ui/views/${view.id}`, view.component_name);
   }
 
   // ── Render ────────────────────────────────────────────────────────────────

--- a/react/src/components/root/ContextualPanel.tsx
+++ b/react/src/components/root/ContextualPanel.tsx
@@ -131,16 +131,36 @@ export default function ContextualPanel({ open, panelType, panelId, onClose }: P
 
 function ViewPreview({ viewId }: { viewId: string }) {
   const [view, setView] = useState<GeneratedView | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<"preview" | "source">("preview");
 
   useEffect(() => {
-    api.listViews().then((views) => {
-      const found = views.find((v) => v.id === viewId);
-      if (found) setView(found);
-    });
+    setError(null);
+    api.listViews()
+      .then((views) => {
+        const found = views.find((v) => v.id === viewId);
+        if (!found) {
+          setError("Generated view not found. It may have been deleted.");
+          setView(null);
+          return;
+        }
+        setView(found);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load generated view");
+        setView(null);
+      });
   }, [viewId]);
 
-  if (!view) return null;
+  if (!view) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="caption" color={error ? "error" : "text.secondary"}>
+          {error ?? "Loading view…"}
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
@@ -167,7 +187,7 @@ function ViewPreview({ viewId }: { viewId: string }) {
               <IconButton
                 size="small"
                 component="a"
-                href={`/ui/${view.component_name}`}
+                href={`/ui/views/${view.id}`}
                 target="_blank"
                 rel="noopener"
               >
@@ -177,7 +197,7 @@ function ViewPreview({ viewId }: { viewId: string }) {
           </Box>
           <Box
             component="iframe"
-            src={`/ui/${view.component_name}`}
+            src={`/ui/views/${view.id}`}
             sx={{
               flexGrow: 1,
               border: "1px solid",

--- a/react/src/components/root/api.ts
+++ b/react/src/components/root/api.ts
@@ -344,6 +344,23 @@ export const promoteAppManifest = (id: string, status: string) =>
 export const deleteAppManifest = (id: string) =>
   request<void>(`/api/apps/manifests/${id}`, { method: "DELETE" });
 
+export const getAppManifestLaunch = (id: string) =>
+  request<{
+    target_type: "manifest";
+    manifest_id: string;
+    view_id: string;
+    component_name: string;
+    mount_url: string;
+  }>(`/api/apps/manifests/${id}/launch`);
+
+export const getViewLaunch = (viewRef: string) =>
+  request<{
+    target_type: "view";
+    view_id: string;
+    component_name: string;
+    mount_url: string;
+  }>(`/api/apps/views/${encodeURIComponent(viewRef)}/launch`);
+
 // ── Tool traces ────────────────────────────────────────────────────────────
 
 export const listToolTraces = (params?: {


### PR DESCRIPTION
### Motivation
- Provide stable, ID-based UI mount points for AI-generated React views and app manifests instead of relying on fragile source paths.
- Resolve mount targets from persisted metadata (DB) so launcher flows can open generated UIs reliably across dev/static modes.
- Support both Vite dev mode (module entries) and static production mode (built `dist` entries) with clear errors when assets or DB records are missing.
- Surface user-facing errors in the dashboard when manifests or views referenced by the UI are missing or invalid.

### Description
- Added repository helpers to resolve generated views from DB metadata: `get_view_by_component_name` and `resolve_view_ref` which accepts either a view ID or component name. (`harness/data/repository.py`)
- Added two launch-resolution APIs to validate and return canonical mount URLs: `GET /api/apps/manifests/{id}/launch` and `GET /api/apps/views/{view_ref}/launch`. (`harness/server/routes/app_routes.py`)
- Implemented new proxy routes to mount UIs stably:
  - `/ui/views/{view_ref}` mounts a generated view (resolves view -> component_name from DB).
  - `/ui/apps/{manifest_id}` mounts an app manifest and injects manifest permissions/state.
  - `/dist/{path}` serves built static assets for non-debug mode.
  These routes render a small shell that injects harness vars and either points at Vite dev entries in debug mode or resolves built JS/CSS from `react/dist/.vite/manifest.json` in static mode. (`harness/server/routes/proxy.py`)
- Frontend changes to use stable mount endpoints and show user-friendly errors:
  - Chat-generated view opens workspace at `/ui/views/{view.id}` instead of a component-name path. (`react/src/components/root/ChatPanel.tsx`)
  - View preview iframe and open-in-new-tab links use `/ui/views/{view.id}` and the preview panel shows an error if the view record is missing. (`react/src/components/root/ContextualPanel.tsx`)
  - App Manifest panel now validates via the new launch API before opening `/ui/apps/{manifest.id}` and displays error text on failure. (`react/src/components/root/AppManifestPanel.tsx`)
  - Typed API helpers were added for the new launch endpoints. (`react/src/components/root/api.ts`)
- Existing legacy `/ui/{component_id}` behavior is preserved for backward compatibility.

### Testing
- `python -m py_compile harness/data/repository.py harness/server/routes/app_routes.py harness/server/routes/proxy.py` — succeeded.
- `cd react && npm run -s build` — succeeded (frontend built and `dist` generated).
- `pytest -q tests/test_repository.py tests/test_views_routes.py tests/test_chat_routes.py` — could not run to completion in this environment due to missing test dependency `pytest_asyncio` (ModuleNotFoundError).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecdff5b044832a9318fe2785177867)