### PR TITLE
Add tests for UI proxy and service lifecycle; enable static /ui/root serving

### DIFF
--- a/harness/server/routes/proxy.py
+++ b/harness/server/routes/proxy.py
@@ -8,6 +8,8 @@ React app's JS/CSS from the FastAPI origin.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
@@ -15,6 +17,14 @@ from fastapi.responses import HTMLResponse, Response
 from harness.server.injector import inject_harness_vars
 
 router = APIRouter()
+
+
+def _react_dist_dir(settings: object) -> Path:
+    """Resolve the built React dist directory for static mode."""
+    configured = getattr(settings, "react_dist_dir", "")
+    if configured:
+        return Path(str(configured)).expanduser().resolve()
+    return (Path(__file__).resolve().parents[3] / "react" / "dist").resolve()
 
 
 async def _proxy_to_vite(path: str, vite_url: str) -> Response:
@@ -40,6 +50,36 @@ async def serve_root_ui(request: Request, path: str = "") -> Response:
     """Serve the main VLoop Harness dashboard from react/index.html."""
     settings = request.app.state.settings
     vite_url = f"http://{settings.vite_host}:{settings.vite_port}"
+    debug_mode = bool(getattr(settings, "harness_debug", True))
+
+    if not debug_mode:
+        dist_dir = _react_dist_dir(settings)
+        if not dist_dir.exists():
+            raise HTTPException(status_code=503, detail=f"React dist directory not found: {dist_dir}")
+
+        rel = path or "index.html"
+        candidate = (dist_dir / rel).resolve()
+        try:
+            candidate.relative_to(dist_dir)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail="Asset not found") from exc
+        if not candidate.exists() or not candidate.is_file():
+            raise HTTPException(status_code=404, detail="Asset not found")
+        content = candidate.read_text(encoding="utf-8") if candidate.suffix == ".html" else candidate.read_bytes()
+        if candidate.suffix != ".html":
+            return Response(content=content)
+
+        api_base = f"http://{settings.harness_host}:{settings.harness_port}"
+        ws_base = f"ws://{settings.harness_host}:{settings.harness_port}"
+        html = inject_harness_vars(
+            html=str(content),
+            component_id="root",
+            api_base=api_base,
+            ws_base=ws_base,
+            initial_state={},
+            permissions=[],
+        )
+        return HTMLResponse(content=html)
 
     # Non-HTML sub-paths (e.g. HMR WebSocket upgrade requests) go straight to Vite.
     if path:

--- a/tests/test_agent_routes.py
+++ b/tests/test_agent_routes.py
@@ -200,3 +200,26 @@ class TestAppManifestRoutes:
         resp = await app_client.get("/api/apps/traces")
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+
+    async def test_ui_contract_manifest_react_views_produce_stable_workspace_url(
+        self, app_client: AsyncClient
+    ) -> None:
+        """UI contract: workspace-open URL is derived from first react view."""
+        create = await app_client.post(
+            "/api/apps/manifests",
+            json={
+                "name": "Finance Cockpit",
+                "status": "active",
+                "react_views": ["RevenueDashboard", "OpsView"],
+            },
+        )
+        assert create.status_code == 201
+        manifest_id = create.json()["id"]
+
+        get_resp = await app_client.get(f"/api/apps/manifests/{manifest_id}")
+        assert get_resp.status_code == 200
+        manifest = get_resp.json()
+
+        # Matches AppManifestPanel's `href={`/ui/${m.react_views[0]}`}` contract.
+        first_view_url = f"/ui/{manifest['react_views'][0]}"
+        assert first_view_url == "/ui/RevenueDashboard"

--- a/tests/test_proxy_routes.py
+++ b/tests/test_proxy_routes.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from harness.server.routes import proxy
+
+
+class _FakeViteResponse:
+    def __init__(self, text: str = "<html><head></head><body>ok</body></html>", status_code: int = 200) -> None:
+        self.text = text
+        self.content = text.encode()
+        self.status_code = status_code
+        self.headers = {"content-type": "text/html"}
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses: list[_FakeViteResponse] | None = None, exc: Exception | None = None):
+        self._responses = responses or [_FakeViteResponse()]
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def get(self, *_args, **_kwargs):
+        if self._exc is not None:
+            raise self._exc
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def proxy_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(proxy.router)
+    app.state.main_process = MagicMock()
+    app.state.settings = SimpleNamespace(
+        harness_host="127.0.0.1",
+        harness_port=8000,
+        vite_host="127.0.0.1",
+        vite_port=5173,
+        harness_debug=True,
+        react_dist_dir="",
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_ui_root_debug_mode_proxies_vite_index(proxy_app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", lambda: _FakeAsyncClient())
+
+    async with AsyncClient(transport=ASGITransport(app=proxy_app), base_url="http://test") as client:
+        resp = await client.get("/ui/root")
+
+    assert resp.status_code == 200
+    assert "window.__HARNESS__" in resp.text
+    assert '"API_URL": "http://127.0.0.1:8000/api/root"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_ui_root_debug_mode_missing_vite_returns_503(proxy_app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        proxy.httpx,
+        "AsyncClient",
+        lambda: _FakeAsyncClient(exc=httpx.ConnectError("boom", request=httpx.Request("GET", "http://vite"))),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=proxy_app), base_url="http://test") as client:
+        resp = await client.get("/ui/root")
+
+    assert resp.status_code == 503
+    assert "unreachable" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ui_root_static_mode_serves_react_dist(proxy_app: FastAPI, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dist = tmp_path / "react" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html><head></head><body>static</body></html>", encoding="utf-8")
+
+    proxy_app.state.settings.harness_debug = False
+    proxy_app.state.settings.react_dist_dir = str(dist)
+
+    # Ensure static mode does not rely on Vite.
+    monkeypatch.setattr(proxy.httpx, "AsyncClient", lambda: _FakeAsyncClient(exc=AssertionError("vite should not be called")))
+
+    async with AsyncClient(transport=ASGITransport(app=proxy_app), base_url="http://test") as client:
+        resp = await client.get("/ui/root")
+
+    assert resp.status_code == 200
+    assert "window.__HARNESS__" in resp.text
+    assert "static" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_ui_root_static_mode_missing_dist_returns_503(proxy_app: FastAPI) -> None:
+    proxy_app.state.settings.harness_debug = False
+    proxy_app.state.settings.react_dist_dir = "/definitely/missing/react/dist"
+
+    async with AsyncClient(transport=ASGITransport(app=proxy_app), base_url="http://test") as client:
+        resp = await client.get("/ui/root")
+
+    assert resp.status_code == 503
+    assert "dist directory" in resp.json()["detail"].lower()

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from harness.core.base_component import BaseComponent
+from harness.core.process_manager import ProcessManager
+
+
+class DummyComponent(BaseComponent):
+    def __init__(self, component_id: str = "svc") -> None:
+        super().__init__(component_id=component_id)
+        self.mounted = 0
+        self.unmounted = 0
+        self.cleaned = 0
+
+    async def on_mount(self) -> None:
+        self.mounted += 1
+
+    async def on_unmount(self) -> None:
+        self.unmounted += 1
+
+    async def cleanup(self) -> None:
+        self.cleaned += 1
+        await super().cleanup()
+
+
+@pytest.mark.asyncio
+async def test_start_stop_status_and_restart_transitions() -> None:
+    logger = MagicMock()
+    manager = ProcessManager(logger)
+    comp = DummyComponent("svc-a")
+
+    assert manager.is_running("svc-a") is False
+
+    await manager.start(comp)
+    assert manager.is_running("svc-a") is True
+    assert comp.mounted == 1
+
+    # idempotent start while already running
+    await manager.start(comp)
+    assert comp.mounted == 1
+
+    await manager.restart(comp)
+    assert manager.is_running("svc-a") is True
+    assert comp.unmounted == 1
+    assert comp.cleaned == 1
+    assert comp.mounted == 2
+
+    await manager.stop(comp)
+    assert manager.is_running("svc-a") is False
+    assert comp.unmounted == 2
+    assert comp.cleaned == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_cleans_up_even_if_unmount_fails() -> None:
+    logger = MagicMock()
+    manager = ProcessManager(logger)
+
+    class BrokenUnmount(DummyComponent):
+        async def on_unmount(self) -> None:  # type: ignore[override]
+            self.unmounted += 1
+            raise RuntimeError("boom")
+
+    comp = BrokenUnmount("svc-b")
+    await manager.start(comp)
+
+    await manager.stop(comp)
+
+    assert comp.unmounted == 1
+    assert comp.cleaned == 1
+    assert manager.is_running("svc-b") is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_watchdog_logs_crashed_task() -> None:
+    logger = MagicMock()
+    manager = ProcessManager(logger)
+
+    async def crash() -> None:
+        raise RuntimeError("task crashed")
+
+    task = asyncio.create_task(crash())
+    await asyncio.sleep(0)
+    manager._tasks["svc-c"] = task
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(manager.watchdog(interval=0.01), timeout=0.03)
+
+    assert logger.error.call_count >= 1
+    assert "crashed" in logger.error.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_background_task_and_cleans_up() -> None:
+    logger = MagicMock()
+    manager = ProcessManager(logger)
+    comp = DummyComponent("svc-d")
+
+    await manager.start(comp)
+
+    async def long_running() -> None:
+        await asyncio.sleep(100)
+
+    manager._tasks[comp.id] = asyncio.create_task(long_running())
+    await manager.stop(comp)
+
+    assert manager.is_running(comp.id) is False
+    assert comp.cleaned == 1
+    assert comp.unmounted == 1


### PR DESCRIPTION
### Motivation
- Cover critical deployment/runtime paths around the root UI proxy, static builds, and service lifecycle to catch regressions between Vite debug mode and static (dist) deployments.
- Ensure the UI contract that workspace open links are stable and derived from app manifest data so the React UI and backend remain compatible.

### Description
- Implement static-mode serving for `/ui/root` in `harness/server/routes/proxy.py` with a `_react_dist_dir` helper, safe path resolution, injected harness vars into HTML, and explicit errors for missing dist or assets when `harness_debug` is false.
- Add `tests/test_proxy_routes.py` with isolated tests that mock `httpx.AsyncClient` and use `tmp_path` to verify `/ui/root` in debug (Vite proxy) and static (`react/dist`) modes, plus failure modes for missing Vite and missing dist.
- Add `tests/test_service_manager.py` exercising `ProcessManager` start/stop/restart, cleanup semantics, background-task cancellation, and watchdog crash logging using a `DummyComponent` and short-lived async tasks.
- Add a UI contract test to `tests/test_agent_routes.py` asserting workspace URLs open as `/ui/{first_react_view}` derived from `AppManifest.react_views` to match the React `AppManifestPanel` behavior, and keep tests fast and isolated via tmp dirs and mocks.

### Testing
- Ran `python -m compileall harness/server/routes/proxy.py tests/test_proxy_routes.py tests/test_service_manager.py tests/test_agent_routes.py` which completed successfully.
- Attempted to run `pytest -q tests/test_proxy_routes.py tests/test_service_manager.py tests/test_agent_routes.py`, but the run was blocked in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'pytest_asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecdff835f4832ab28cff605a4a889a)