### PR TITLE
Pass HARNESS_DEBUG=false to backend in static frontend mode and add env overrides

### DIFF
--- a/harness/core/service_manager.py
+++ b/harness/core/service_manager.py
@@ -122,7 +122,12 @@ class ServiceManager:
             "--port",
             str(self.backend_port),
         ]
-        proc = self._spawn_service("backend", cmd, cwd=self.repo_root)
+        proc = self._spawn_service(
+            "backend",
+            cmd,
+            cwd=self.repo_root,
+            env_overrides={"HARNESS_DEBUG": "false" if self.frontend_mode == "static" else "true"},
+        )
 
         if not self._wait_for_port(self.backend_host, self.backend_port, timeout=20.0):
             err = self._read_log_tail("backend")
@@ -273,8 +278,17 @@ class ServiceManager:
 
     # ── Process utilities ────────────────────────────────────────────────────
 
-    def _spawn_service(self, name: ServiceName, cmd: list[str], cwd: Path) -> subprocess.Popen[bytes]:
+    def _spawn_service(
+        self,
+        name: ServiceName,
+        cmd: list[str],
+        cwd: Path,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.Popen[bytes]:
         log_file = self._service_log(name)
+        env = os.environ.copy()
+        if env_overrides:
+            env.update(env_overrides)
         with log_file.open("ab") as log:
             proc = subprocess.Popen(
                 cmd,
@@ -282,6 +296,7 @@ class ServiceManager:
                 stdout=log,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
+                env=env,
             )
         self._write_pid(name, proc.pid, cmd, cwd)
         return proc

--- a/tests/test_service_manager.py
+++ b/tests/test_service_manager.py
@@ -40,3 +40,38 @@ def test_cleanup_orphans_removes_stale_pid(tmp_path) -> None:
     manager.cleanup_orphans()
 
     assert not pid_path.exists()
+
+
+def test_start_backend_sets_harness_debug_for_static_mode(tmp_path, monkeypatch) -> None:
+    manager = _manager(tmp_path, frontend_mode="static")
+    captured: dict[str, str] = {}
+
+    def fake_status_for(_name: str):
+        from harness.core.service_manager import ServiceStatus
+
+        return ServiceStatus(
+            name="backend",
+            running=False,
+            healthy=False,
+            pid=None,
+            log_path=manager._service_log("backend"),
+        )
+
+    class DummyProc:
+        pid = 12345
+
+    def fake_spawn_service(_name, _cmd, cwd, env_overrides=None):  # type: ignore[no-untyped-def]
+        assert cwd == manager.repo_root
+        if env_overrides:
+            captured.update(env_overrides)
+        manager._write_pid("backend", DummyProc.pid, ["python"], cwd)
+        return DummyProc()
+
+    monkeypatch.setattr(manager, "_status_for", fake_status_for)
+    monkeypatch.setattr(manager, "_port_in_use", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(manager, "_wait_for_port", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(manager, "_spawn_service", fake_spawn_service)
+
+    manager.start("backend")
+
+    assert captured.get("HARNESS_DEBUG") == "false"


### PR DESCRIPTION
### Motivation
- Recent changes introduced static UI serving when `HARNESS_DEBUG=false` and a new `ServiceManager` that can run with `frontend_mode="static"`, but the backend subprocess was still launched without toggling its debug env, causing mismatched runtime behavior.
- The intent is to make static frontend mode end-to-end consistent by ensuring the backend worker subprocess runs with `HARNESS_DEBUG=false` when appropriate.

### Description
- `ServiceManager._start_backend()` now passes `env_overrides={"HARNESS_DEBUG": "false"}` when `frontend_mode == "static"` (and `"true"` otherwise) to control backend runtime mode.
- `_spawn_service()` signature extended to accept `env_overrides: dict[str,str] | None` and the subprocess is started with a merged environment (`os.environ.copy()` updated by `env_overrides`).
- Added `test_start_backend_sets_harness_debug_for_static_mode` to `tests/test_service_manager.py` which stubs service start and asserts the backend launch receives `HARNESS_DEBUG="false"` in static mode.

### Testing
- Ran `python -m compileall harness/core/service_manager.py tests/test_service_manager.py`, which succeeded.
- Ran `pytest -q tests/test_service_manager.py` in this environment, which could not complete due to a missing test dependency (`pytest_asyncio` imported by `tests/conftest.py`).
- New regression test was added and compiles; full test run should pass once test environment provides `pytest_asyncio`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ece6cbf974832a9d0268bda027a62a)