### PR TITLE
Rewrite README to 'Vloop Harness' and add comprehensive docs (API, ARCHITECTURE, SETUP, CONTRIBUTING, CHANGELOG, ADRs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,455 +1,158 @@
-# HARNESS — Architecture README
+# Vloop Harness
+Vloop Harness is a local-first AI engineering workbench that combines a Python orchestration backend with a React control-plane UI for building, running, and evaluating DSPy-based agents and pipelines.
 
-A native binary harness where Python components run logic/state/events and pair 1:1 with React UI apps. In debug, UI is served through a shared Vite dev server; in production/static mode, UI is served from prebuilt `react/dist` files. Components run as mini-apps inside a resizable root window. Python is the brain. React is the face.
+## Overview
+Vloop Harness provides a FastAPI backend, a dynamic tool runtime (terminal, filesystem, browser, database), and a React dashboard for chat, component authoring, pipeline execution, view generation, and agent run orchestration. It is designed for engineers iterating on AI components with auditable state and policy-constrained tool access. The backend persists metadata in SQLite by default (with optional PostgreSQL), including chat transcripts, provider configs, component definitions, pipeline specs, app manifests, tool traces, and agent run logs. Architecturally, the system separates runtime concerns into core process orchestration, API routes, AI engine modules, and persistence layers, while keeping UI concerns in a separate Vite/React project.
 
-> **Current implementation note:** the repository currently has a chat-first
-> root dashboard with DSPy, pipeline, tools, settings, and generated-view panels.
-> The resizable multi-view window manager described below is target architecture.
-> See [`DOCS/full-stack-agents-harness-plan.md`](DOCS/full-stack-agents-harness-plan.md)
-> for the updated full-stack agents harness plan and implementation parity map.
-
------
-
-## Top-Level Overview
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  NATIVE BINARY (PyInstaller)                                                │
-│                                                                             │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Root Window (PyWebView)                                             │   │
-│  │                                                                      │   │
-│  │  ┌─────────────────────────────────────────────────────────────┐     │   │
-│  │  │  Root UI  (localhost:3000/root)                             │     │   │
-│  │  │                                                             │     │   │
-│  │  │  ┌──────────────────┐  ┌──────────────────┐                 │     │   │
-│  │  │  │  View A          │  │  View B          │  ...            │     │   │
-│  │  │  │  /ui/comp_a/     │  │  /ui/comp_b/     │                 │     │   │
-│  │  │  │                  │  │                  │                 │     │   │
-│  │  │  │  [React App A]   │  │  [React App B]   │                 │     │   │
-│  │  │  │                  │  │                  │                 │     │   │
-│  │  │  │  [resize/move]   │  │  [minimise/close]│                 │     │   │
-│  │  │  └──────────────────┘  └──────────────────┘                 │     │   │
-│  │  └─────────────────────────────────────────────────────────────┘     │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                             │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  MainProcess (Python)                                                │   │
-│  │  ├─ ComponentTree                                                    │   │
-│  │  ├─ ProcessManager                                                   │   │
-│  │  ├─ PermissionsGuard                                                 │   │
-│  │  ├─ StateStore                                                       │   │
-│  │  └─ Logger                                                           │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                             │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  FastAPI Server                                                      │   │
-│  │  ├─ REST  /api/{component_id}/*                                      │   │
-│  │  ├─ WS    /ws/{component_id}                                         │   │
-│  │  └─ SERVE /ui/{component_id}/{*react_routes}  (injects env vars)     │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                             │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Vite Dev Server  (localhost:5173)                                   │   │
-│  │  ├─ Single React monorepo                                            │   │
-│  │  ├─ One entry per component: src/components/{component_id}/App.tsx   │   │
-│  │  └─ Hot module reload on file change                                 │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
+## Architecture
+```mermaid
+flowchart LR
+  UI[React Dashboard\nVite on :5173 in dev] -->|HTTP/WS| API[FastAPI Server]
+  API --> MP[MainProcess\nComponent + Tool Orchestration]
+  API --> ENG[DSPy Engine\nProviderManager\nPipelineBuilder]
+  API --> REPO[Repository Layer]
+  REPO --> DB[(SQLite/PostgreSQL)]
+  MP --> TOOLS[Tool Registry\nTerminal/Filesystem/Browser/DB]
+  API --> VSTORE[VLoop Storage\n.vloop files + logs]
+  ENG --> LLM[Anthropic/OpenAI/Ollama]
 ```
 
------
+## Tech Stack
+| Layer | Technology | Version | Purpose |
+|---|---|---|---|
+| Backend runtime | Python | >=3.11 | Core runtime for API, orchestration, tools |
+| Backend framework | FastAPI | >=0.115.0 | HTTP + WebSocket API |
+| ASGI server | Uvicorn | >=0.32.0 | FastAPI serving |
+| CLI | Typer | >=0.15.0 | `harness` command and service control |
+| AI orchestration | DSPy | >=2.5.0 | LLM module/pipeline execution |
+| LLM providers | anthropic/openai SDKs | >=0.40.0 / >=1.57.0 | Hosted model access |
+| Data access | SQLAlchemy asyncio | >=2.0.0 | ORM + async DB sessions |
+| Default DB | SQLite + aiosqlite | >=0.20.0 | Local metadata persistence |
+| Optional DB | PostgreSQL + asyncpg | >=0.30.0 | External production-style DB |
+| Frontend runtime | Node.js + npm | >=18.18.0 | React/Vite toolchain |
+| Frontend framework | React | ^18.3.1 | Root dashboard UI |
+| Frontend build tool | Vite | ^6.0.3 | Dev server + bundling |
+| UI component library | MUI | ^5.16.x | Dashboard components |
+| E2E testing | Playwright | ^1.56.1 | Browser-level tests |
+| Python testing | pytest/pytest-asyncio | >=8.3.0 / >=0.24.0 | Unit/integration tests |
+| Linting/type checks | Ruff + mypy + TypeScript | >=0.8.0 / >=1.13.0 / ^5.6.3 | Static quality checks |
 
-## Python Component System
-
-### BaseComponent
-
-Every component inherits from `BaseComponent`. Pure Python — no UI code.
-
-```
-BaseComponent
-├── id: str                     (auto-generated UUID)
-├── props: dict                 (passed from parent or MainProcess)
-├── state: dict                 (internal, managed by Python)
-├── children: list[BaseComponent]
-├── permissions: PermissionSet
-│
-├── on_mount()                  → called when view opens
-├── on_unmount()                → called when view is closed (hard)
-├── on_hide()                   → called when view is minimised
-├── on_show()                   → called when view is restored
-├── on_update(new_props)        → called when parent pushes new props
-├── on_event(name, payload)     → called when React emits event
-│
-├── emit(name, payload)         → push event to paired React UI
-├── update_state(patch)         → merge patch into state, notify React
-├── get_snapshot()              → return serialisable state dict
-└── cleanup()                   → release resources, kill threads
+## Prerequisites
+```bash
+python --version      # must be 3.11+
+node --version        # must be >=18.18.0
+npm --version
 ```
 
-### Component Lifecycle
+## Getting Started
+```bash
+git clone <repo-url>
+cd Vloop-harness
 
-```
-CREATE
-  ↓
-MainProcess.register(component)
-  ↓
-ProcessManager.start(component)     → on_mount()
-  ↓
-FastAPI registers /api/{id}/* routes
-FastAPI registers /ws/{id}
-  ↓
-RootUI told: "mount view for {id}"
-  ↓
-View iframe loads /ui/{id}/
-  ↓
-Vite serves HTML with injected:
-  COMPONENT_ID, API_URL, WS_URL, INITIAL_STATE
-  ↓
-React app boots, connects WS, renders UI
-  ↓
-RUNNING (events flow both ways)
+# 1) Python environment + backend dependencies
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
 
-────────── HIDE (minimise) ──────────
-RootUI hides iframe (display:none)
-Component.on_hide()
-Process stays alive. State preserved.
+# 2) Frontend dependencies
+cd react
+npm install
+cd ..
 
-────────── SHOW (restore) ───────────
-RootUI shows iframe
-Component.on_show()
-React re-syncs state via WS
+# 3) Environment setup
+cp .env.example .env
+# Edit .env and set API keys if using hosted providers.
 
-────────── CLOSE (unmount) ──────────
-RootUI removes iframe
-Component.on_unmount()
-Component.cleanup()
-ProcessManager.stop(component)
-FastAPI removes routes for {id}
-StateStore flushes component state
-Logger records shutdown
+# 4) Start backend + frontend services
+python -m harness.main services start all
+
+# 5) Open app
+# Visit http://localhost:8000/ui/root
+
+# 6) Stop services when done
+python -m harness.main services stop all
 ```
 
------
-
-## MainProcess
-
-Owns everything. Single entrypoint.
-
-```
-MainProcess
-│
-├── ComponentTree
-│   ├── root: RootComponent
-│   ├── register(component)
-│   ├── unregister(component_id)
-│   ├── get(component_id)
-│   ├── list_all()
-│   └── broadcast(event)           → sends to all components
-│
-├── ProcessManager
-│   ├── start(component)           → on_mount + route registration
-│   ├── stop(component)            → on_unmount + cleanup
-│   ├── restart(component)         → stop → start (hot reload)
-│   ├── list_running()
-│   └── watchdog()                 → monitor crashed components
-│
-├── StateStore
-│   ├── set(component_id, key, val)
-│   ├── get(component_id, key)
-│   ├── persist()                  → save to disk (JSON/SQLite)
-│   ├── restore()                  → load from disk on boot
-│   └── flush(component_id)        → clear on unmount
-│
-├── PermissionsGuard
-│   ├── PermissionSet per component (filesystem, network, shell, ipc)
-│   ├── check(component_id, permission)
-│   ├── grant(component_id, permission)
-│   └── revoke(component_id, permission)
-│
-└── Logger
-    ├── Per-component log streams
-    ├── Log levels: DEBUG, INFO, WARN, ERROR
-    ├── log(component_id, level, message)
-    ├── tail(component_id, n)
-    └── export(component_id, path)
+## Project Structure
+```text
+.
+├── harness/                 # Python backend package
+│   ├── core/                # MainProcess, lifecycle, permissions, state/log orchestration
+│   ├── data/                # SQLAlchemy models, DB initialization, repository layer
+│   ├── engine/              # DSPy engine, providers, pipeline builder, agent modules
+│   ├── server/              # FastAPI app factory, routes, HTML injector
+│   ├── tools/               # Tool implementations + policy/confirmation runtime
+│   ├── vloop/               # Project storage + encryption + redaction helpers
+│   ├── components/          # Example/legacy Python components
+│   ├── main.py              # CLI entrypoint (`harness`)
+│   └── settings.py          # Env-backed settings model
+├── react/                   # React/Vite dashboard
+│   ├── src/components/root/ # Main root dashboard panels
+│   ├── src/harness/         # Frontend harness types/hooks/provider
+│   └── tests/e2e/           # Playwright tests
+├── tests/                   # Python backend test suite
+├── docs/                    # Project documentation set
+├── DOCS/                    # Legacy docs (historical/reference)
+├── .env.example             # Environment variable template
+└── pyproject.toml           # Python project metadata and tooling config
 ```
 
------
+## Environment Variables
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| HARNESS_HOST | No | `localhost` | FastAPI host bind/address |
+| HARNESS_PORT | No | `8000` | FastAPI port |
+| HARNESS_DEBUG | No | `true` | `true`: proxy Vite dev server; `false`: serve `react/dist` |
+| VITE_HOST | No | `localhost` | Vite host used by proxy/health checks |
+| VITE_PORT | No | `5173` | Vite port |
+| DSPY_LM_PROVIDER | No | `anthropic` | Active provider type (`anthropic` / `openai` / `ollama`) |
+| DSPY_LM_MODEL | No | `claude-sonnet-4-6` | Default model name |
+| ANTHROPIC_API_KEY | Yes* | none | **Secret**. Required when using Anthropic |
+| OPENAI_API_KEY | Yes* | none | **Secret**. Required when using OpenAI |
+| OLLAMA_BASE_URL | No | `http://localhost:11434` | Ollama endpoint |
+| STATE_DB_PATH | No | `.harness/state.db` | Legacy harness state DB path |
+| LOG_DIR | No | `.harness/logs` | Harness logs directory |
+| VLOOP_DB_URL | No | empty -> SQLite fallback | Async SQLAlchemy DB URL override |
+| VLOOP_PROJECT_DIR | No | empty -> CWD/.vloop | Override `.vloop` data directory |
+| TOOLS_POLICY_PATH | No | `<workspace>/.vloop/policy.json` | Optional tool policy override |
 
-## FastAPI Layer
+\* Required only for corresponding provider.
 
-Single server. Routes dynamically registered per component.
+## Available Scripts
+### Python (`pyproject.toml` / CLI)
+- `harness run`: start orchestrator; optional `--no-window` and `--frontend-mode dev|static`.
+- `harness services start [backend|frontend|all]`: start managed subprocess services.
+- `harness services stop [backend|frontend|all]`: stop services.
+- `harness services restart [backend|frontend|all]`: restart services.
+- `harness services status`: report PID + health for services.
+- `harness internal backend-worker`: internal-only backend launch command.
 
+### Frontend (`react/package.json`)
+- `npm run dev`: start Vite dev server.
+- `npm run build`: run TS check then build production assets.
+- `npm run preview`: preview production build.
+- `npm run typecheck`: TypeScript no-emit type check.
+- `npm run test:e2e`: run headless Playwright suite.
+- `npm run test:e2e:headed`: run headed Playwright suite.
+
+## Testing
+```bash
+# Python tests
+pytest
+
+# Optional with coverage
+pytest --cov=harness --cov-report=term-missing
+
+# Frontend type safety
+cd react && npm run typecheck
+
+# Frontend e2e
+cd react && npm run test:e2e
 ```
-Static Routes:
-  GET  /                          → root window HTML
-  GET  /api/components            → list all running components
-  POST /api/components            → create new component (runtime)
-  DELETE /api/components/{id}     → destroy component
+Python tests cover route behavior, permissions/policy, storage/repository behavior, and tool execution flows. E2E coverage exists for key root UI behavior via Playwright.
 
-Dynamic Routes (registered on component mount):
-  GET  /api/{component_id}/state          → current state snapshot
-  POST /api/{component_id}/event          → React → Python event
-  POST /api/{component_id}/props          → update props from parent
-  WS   /ws/{component_id}                 → bidirectional event stream
+## Deployment
+Current deployment is process-managed local service startup via the CLI service manager. `frontend_mode=static` enables production-style serving from `react/dist` directly behind FastAPI. CI/CD workflow files are not present in this repository, so deployment checks are currently expected to run locally (`pytest`, TypeScript checks, and optional Playwright e2e) before merge.
 
-UI Serving:
-  GET  /ui/{component_id}/{*react_routes}
-       → If HARNESS_DEBUG=true: FastAPI proxies Vite dev server
-       → If HARNESS_DEBUG=false: FastAPI serves files from react/dist
-       → Injects into <head>:
-           window.__HARNESS__ = {
-             COMPONENT_ID: "{id}",
-             API_URL: "http://localhost:8000/api/{id}",
-             WS_URL:  "ws://localhost:8000/ws/{id}",
-             INITIAL_STATE: {...},
-             PERMISSIONS: [...]
-           }
-```
-
-### Frontend serving mode (`HARNESS_DEBUG`)
-
-- `HARNESS_DEBUG=true` (default): `/ui/*` routes proxy to Vite (`localhost:5173`) for HMR/dev workflows.
-- `HARNESS_DEBUG=false`: `/ui/*` routes serve static build artifacts from `react/dist`:
-  - `/ui/root` → `react/dist/root.html`
-  - `/ui/<component_id>` → `react/dist/<component_id>.html`
-  - `/assets/*` → `react/dist/assets/*`
-
-In both modes, HTML responses are processed by `inject_harness_vars(...)` before being returned so runtime component metadata is always available.
-
------
-
-## Vite / React Layer
-
-Single Vite monorepo. One shared dev server. Each component has its own React app entry.
-
-```
-react/
-├── src/
-│   ├── harness/
-│   │   ├── useHarness.ts       → hook: connects WS, exposes state + emit
-│   │   ├── HarnessProvider.tsx → context: wraps app with WS connection
-│   │   └── types.ts            → shared types
-│   │
-│   └── components/
-│       ├── {component_id_a}/
-│       │   ├── App.tsx         → root of React app for this component
-│       │   └── *.tsx           → any custom UI files
-│       │
-│       └── {component_id_b}/
-│           ├── App.tsx
-│           └── ...
-│
-├── vite.config.ts              → multi-entry: each component_id = own entry
-└── package.json
-```
-
-### useHarness Hook (available in every React app)
-
-```typescript
-const { state, emit, props } = useHarness()
-
-// state   → live Python state (auto-updated via WS)
-// emit    → send event to Python:  emit("click", { x, y })
-// props   → read-only props from Python parent
-```
-
-### HTML Injection (FastAPI does this at serve time)
-
-```html
-<script>
-  window.__HARNESS__ = {
-    COMPONENT_ID: "comp_abc123",
-    API_URL: "http://localhost:8000/api/comp_abc123",
-    WS_URL:  "ws://localhost:8000/ws/comp_abc123",
-    INITIAL_STATE: { "counter": 0 },
-    PERMISSIONS: ["read_state", "emit_events"]
-  }
-</script>
-```
-
-React reads `window.__HARNESS__` on boot. No env files needed per component.
-
------
-
-## Root UI — Window Manager
-
-Root window is a React app at `/root`. It is the shell. Manages views.
-
-```
-RootUI
-├── ViewManager
-│   ├── views: Map<component_id, ViewState>
-│   ├── open(component_id)       → mount iframe, tell Python on_mount
-│   ├── close(component_id)      → remove iframe, tell Python on_unmount
-│   ├── minimize(component_id)   → hide iframe (display:none), tell Python on_hide
-│   └── restore(component_id)    → show iframe, tell Python on_show
-│
-└── View (per component)
-    ├── <iframe src="/ui/{component_id}/" />
-    ├── Resizable  (drag corners)
-    ├── Moveable   (drag title bar)
-    ├── Title bar:
-    │   ├── [─]  minimise  → hide view, process lives
-    │   └── [✕]  close     → remove view, process dies
-    └── Position + size persisted in StateStore
-```
-
-Views float freely in the root window. Can overlap, stack, arrange as needed. Root UI has no knowledge of iframe content — that is the paired React app’s concern.
-
------
-
-## Inter-Component Communication
-
-React apps never talk to each other. All cross-component comms go through Python.
-
-```
-React App A
-  → emit("send_data", payload)
-  → WS → Python Component A.on_event()
-  → Component A calls: MainProcess.ComponentTree.get("comp_b").on_event(...)
-  → Python Component B updates state
-  → Component B.emit("data_received", payload)
-  → WS → React App B re-renders
-```
-
------
-
-## Hot Reload
-
-### Python Components
-
-```
-File watcher monitors /components/*.py
-  → Change detected
-  → ProcessManager.restart(component)
-  → on_unmount() → reimport class → on_mount()
-  → State optionally restored from StateStore
-  → WS notifies React: { type: "reloading" }
-  → React shows loader → reconnects when ready
-```
-
-### React UI
-
-```
-Vite HMR handles automatically.
-  → Edit src/components/{id}/App.tsx
-  → Vite pushes update to iframe
-  → React hot reloads in place
-  → No Python restart needed
-```
-
------
-
-## Runtime Component Creation
-
-```
-1. User opens "New Component" in Root UI
-2. Fills: name, permissions, initial props
-3. Root UI: POST /api/components
-4. MainProcess:
-   ├── Instantiates BaseComponent subclass
-   ├── Registers in ComponentTree
-   └── ProcessManager.start()
-5. Vite stub created: src/components/{new_id}/App.tsx
-6. FastAPI registers routes for {new_id}
-7. Root UI opens view for {new_id}
-8. User edits React file in editor (built-in or external)
-9. Vite HMR updates live in view
-```
-
------
-
-## Directory Structure
-
-```
-harness/
-│
-├── main.py                     → entrypoint: boots everything
-├── window.py                   → PyWebView root window
-│
-├── core/
-│   ├── base_component.py
-│   ├── main_process.py
-│   ├── component_tree.py
-│   ├── process_manager.py
-│   ├── state_store.py
-│   ├── permissions.py
-│   └── logger.py
-│
-├── server/
-│   ├── app.py                  → FastAPI app
-│   ├── routes/
-│   │   ├── components.py       → CRUD
-│   │   ├── proxy.py            → /ui/{id}/* → Vite proxy + injection
-│   │   └── ws.py               → /ws/{id} WebSocket handler
-│   └── injector.py             → injects window.__HARNESS__ into HTML
-│
-├── components/                 → user Python components live here
-│   ├── counter.py
-│   └── dashboard.py
-│
-└── react/                      → Vite monorepo
-    ├── src/
-    │   ├── harness/            → shared hook + context
-    │   └── components/         → one folder per component ID
-    ├── vite.config.ts
-    └── package.json
-```
-
------
-
-## Startup Sequence
-
-```
-1. main.py
-   ├── Boot Logger
-   ├── Boot StateStore (restore persisted state from disk)
-   ├── Boot MainProcess
-   ├── Boot ComponentTree (re-register saved components)
-   ├── Start FastAPI (uvicorn on background thread)
-   ├── Start Vite dev server (subprocess)
-   └── Open PyWebView window → loads localhost:8000/root
-
-2. Root UI loads
-   ├── Connects WS to MainProcess
-   ├── GET /api/components
-   └── Restores saved view layout from StateStore
-
-3. Components mount (on_mount per component)
-
-4. Ready
-```
-
------
-
-## Permissions
-
-Declared per component. Enforced by MainProcess. Components cannot self-escalate.
-
-```
-filesystem.read        → read files from disk
-filesystem.write       → write files to disk
-network.outbound       → make HTTP requests
-network.inbound        → open ports / receive
-shell.exec             → run terminal commands
-ipc.broadcast          → send events to other components
-ipc.receive            → receive events from other components
-state.persist          → write state to disk
-ui.resize              → resize own view
-ui.spawn               → create new child components
-```
-
------
-
-## Core Rules
-
-1. Python is the brain. React renders only.
-1. One Python component ↔ one React app. No sharing.
-1. Cross-component comms via Python only. React is isolated.
-1. View close = process kill. View minimise = process lives.
-1. All state lives in Python. React is stateless beyond UI ephemera.
-1. Permissions are hard enforced. No self-escalation.
-1. Every component has its own log stream.
-1. StateStore persists across restarts. Components resume last state.
+## Contributing
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,160 @@
+# API Reference
+
+Base URL: `http://<HARNESS_HOST>:<HARNESS_PORT>` (default `http://localhost:8000`)
+
+## REST/HTTP API
+
+### [GET] /
+**Description**: Service health/status root.
+**Authentication**: None.
+**Response**: `200` with `{status, service, version}`.
+
+## Component Runtime (`/api/components` + dynamic `/api/{component_id}`)
+### [GET] /api/components
+Lists live registered components.
+### [POST] /api/components
+Creates component from Python class path.
+Body: `{ class_path, props, permissions[] }`.
+### [DELETE] /api/components/{component_id}
+Unregisters/destroys component.
+### [GET] /api/{component_id}/state
+Returns component snapshot.
+### [POST] /api/{component_id}/event
+Body: `{ name, payload }`; forwards event to component.
+### [POST] /api/{component_id}/props
+Body: `{ props }`; updates component props.
+### [GET] /api/{component_id}/logs?n=100
+Returns recent logs.
+
+Errors: `404` component not found, `400` import/validation errors.
+
+## WebSockets
+### [WS] /ws/root
+Dashboard keep-alive WS.
+### [WS] /ws/{component_id}
+Bidirectional component event/state channel.
+Initial server message: `{type:"state_update", data:<state>}`.
+
+## Chat (`/api/chat`)
+### [GET] /api/chat/sessions
+### [POST] /api/chat/sessions
+Body: `{ title }`.
+### [GET] /api/chat/sessions/{session_id}
+### [PATCH] /api/chat/sessions/{session_id}
+Body: `{ title }`.
+### [DELETE] /api/chat/sessions/{session_id}
+### [GET] /api/chat/sessions/{session_id}/messages
+### [GET] /api/chat/sessions/{session_id}/transcript
+### [POST] /api/chat/sessions/{session_id}/messages
+Body: `{ content }`; persists user message and returns assistant response.
+
+Common errors: `404` session not found, `500` model/runtime failures.
+
+## DSPy Components & Pipelines (`/api/dspy`)
+### Components
+- `[GET] /api/dspy/components`
+- `[POST] /api/dspy/components` body `{name, description, code, module_type}`
+- `[GET] /api/dspy/components/{component_id}`
+- `[PUT] /api/dspy/components/{component_id}` partial body fields
+- `[DELETE] /api/dspy/components/{component_id}`
+- `[POST] /api/dspy/components/{component_id}/run` body `{inputs:{...}}`
+
+### Pipelines
+- `[GET] /api/dspy/pipelines`
+- `[POST] /api/dspy/pipelines` body `{name, description, steps[]}`
+- `[GET] /api/dspy/pipelines/{pipeline_id}`
+- `[PUT] /api/dspy/pipelines/{pipeline_id}`
+- `[DELETE] /api/dspy/pipelines/{pipeline_id}`
+- `[POST] /api/dspy/pipelines/{pipeline_id}/run` body `{inputs:{...}}`
+
+Compile/validation errors return `422`; missing records return `404`.
+
+## Evaluation & Versioning (`/api/dspy/components/{component_id}`)
+- `[GET] /versions`
+- `[POST] /snapshot` body `{change_summary}`
+- `[POST] /rollback` body `{version_id}`
+- `[GET] /eval-datasets`
+- `[POST] /eval-datasets` body `{name,description,examples[]}`
+- `[PUT] /eval-datasets/{dataset_id}`
+- `[DELETE] /eval-datasets/{dataset_id}`
+- `[POST] /evaluate` body `{dataset_id}`
+
+## Views (`/api/views`)
+- `[POST] /api/views/generate` body `{description, component_name, spec, session_id}`
+- `[GET] /api/views`
+- `[DELETE] /api/views/{view_id}`
+
+Generation may return `503` if AI engine is not configured.
+
+## Providers & Settings
+- `[GET] /api/settings`
+- `[PUT] /api/settings` body `{settings:{...}}`
+- `[GET] /api/providers`
+- `[POST] /api/providers`
+- `[GET] /api/providers/{provider_id}`
+- `[PUT] /api/providers/{provider_id}`
+- `[DELETE] /api/providers/{provider_id}`
+- `[POST] /api/providers/{provider_id}/set-default`
+- `[GET] /api/providers/{provider_id}/test`
+- `[GET] /api/ollama/models?base_url=...`
+
+## Agent Runs (`/api/agents`)
+- `[POST] /api/agents/runs` body `{goal, session_id, autonomy_mode, context}`
+- `[GET] /api/agents/runs?limit=50`
+- `[GET] /api/agents/runs/{run_id}`
+- `[POST] /api/agents/runs/{run_id}/cancel`
+- `[POST] /api/agents/runs/{run_id}/resume` body `{confirmed_token}`
+- `[DELETE] /api/agents/runs/{run_id}`
+
+## App Manifests (`/api/apps`)
+- `[POST] /api/apps/manifests`
+- `[GET] /api/apps/manifests?status=...`
+- `[GET] /api/apps/manifests/{manifest_id}`
+- `[PUT] /api/apps/manifests/{manifest_id}`
+- `[POST] /api/apps/manifests/{manifest_id}/promote` body `{status}`
+- `[DELETE] /api/apps/manifests/{manifest_id}`
+- `[GET] /api/apps/traces` (tool trace listing)
+
+## Tools (`/api/tools`)
+- `[GET] /api/tools`
+- `[GET] /api/tools/policy`
+- `[PUT] /api/tools/policy`
+- `[GET] /api/tools/workspace`
+- `[POST] /api/tools/terminal`
+- `[POST] /api/tools/filesystem/list|read|stat|write|create|delete|move`
+- `[POST] /api/tools/browser`
+- `[POST] /api/tools/database`
+- `[POST] /api/tools/confirm/{token}`
+- `[DELETE] /api/tools/confirm/{token}`
+
+Some tool operations return `202 Accepted` with `{requires_confirmation:true, token,...}`.
+
+## UI Serving Endpoints
+- `[GET] /ui/root` and `/ui/root/{path}`
+- `[GET] /ui/{component_id}` and `/ui/{component_id}/{path}`
+- `[GET] /src/{path}`, `/@{path}`, `/node_modules/{path}` (debug mode pass-through)
+
+## Authentication & Authorization
+No user authentication middleware is implemented for API access (trusted local environment model). Authorization for dangerous actions is policy-based at tool runtime level, plus optional confirmation tokens.
+
+## Rate Limiting
+No explicit server-side rate-limiting middleware is implemented in this codebase today. Clients should implement retry/backoff on failures and avoid burst traffic against long-running AI/tool endpoints.
+
+## Error Format
+Common FastAPI error shape:
+```json
+{"detail": "..."}
+```
+Tool confirmation special-case (`202`):
+```json
+{
+  "requires_confirmation": true,
+  "token": "...",
+  "description": "...",
+  "risk_level": "...",
+  "expires_in_seconds": 60
+}
+```
+
+## Versioning
+Current API versioning is path-implicit and not namespace-versioned (no `/v1`). Service root and FastAPI app metadata report `0.2.0`. Deprecation policy for this repository is: mark endpoint behavior changes in `docs/CHANGELOG.md`, keep backward compatibility for additive changes, and treat removals/contract-breaking changes as release-gated maintainer decisions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,142 @@
+## System Overview
+Vloop Harness is responsible for orchestrating AI-assisted engineering workflows: chat-driven generation, DSPy component/pipeline execution, tool-mediated actions (filesystem, terminal, browser, database), and persistence of operational artifacts. System boundaries include a local FastAPI server, a React dashboard, and optional remote model providers. It is **not** responsible for remote multi-tenant auth, production job scheduling, or cloud-native deployment automation.
+
+## Architecture Pattern
+The codebase follows a **layered modular monolith** pattern:
+- **Interface layer**: FastAPI routes + WebSockets + React UI.
+- **Application/orchestration layer**: `MainProcess`, `ServiceManager`, `AgentOrchestrator`, DSPy pipeline builder.
+- **Domain/data layer**: SQLAlchemy ORM models + repository abstraction.
+- **Infrastructure layer**: storage, encryption vault, tool adapters, provider SDK integrations.
+
+This pattern fits the domain because workflows are tightly coupled (chat, tooling, DSPy, persistence), but still require strict subsystem boundaries to keep route handlers thin and maintain auditable state transitions.
+
+## Component Diagram
+```mermaid
+flowchart TD
+  subgraph Frontend
+    RUI[React Root Dashboard]
+  end
+
+  subgraph Backend
+    API[FastAPI App + Routers]
+    WS[WebSocket Routes]
+    MP[MainProcess]
+    TR[Tool Registry]
+    ENG[DSPy Engine + ProviderManager]
+    PB[PipelineBuilder + ComponentRegistry]
+    REPO[Repository]
+    DB[(SQLite/PostgreSQL)]
+    VS[VLoopStorage + SecretVault]
+  end
+
+  subgraph External
+    LLM[Anthropic/OpenAI/Ollama]
+  end
+
+  RUI -->|HTTP| API
+  RUI -->|WS| WS
+  API --> MP
+  API --> ENG
+  API --> PB
+  API --> REPO
+  WS --> MP
+  MP --> TR
+  REPO --> DB
+  API --> VS
+  ENG -->|SDK/API| LLM
+  PB --> TR
+```
+
+## Directory Structure Deep Dive
+- `harness/core/`: process lifecycle and runtime governance (`MainProcess`, permissions, state store, logger, component tree/process manager). Keep orchestration only; no route-specific parsing.
+- `harness/server/`: FastAPI app factory and route modules. Keep HTTP contracts, validation, and serialization here; business persistence belongs in repository/services.
+- `harness/engine/`: DSPy runtime wiring, providers, codegen/reasoning modules, and pipeline execution. Avoid direct HTTP coupling here.
+- `harness/data/`: ORM schema + DB/session init + repository API. Route handlers should avoid raw SQLAlchemy access outside this layer.
+- `harness/tools/`: sandboxed tool implementations with policy and confirmation gatekeeping.
+- `harness/vloop/`: project-local filesystem structure, key management, and redaction utilities.
+- `react/src/components/root/`: dashboard surface (panels for chat, eval, tools, settings, etc.).
+- `tests/`: Python tests grouped by route/tool/core module behavior.
+- `react/tests/e2e/`: browser-level test flows.
+
+## Data Architecture
+### Key entities
+- `ChatSession`, `ChatMessage`: conversational records.
+- `DSPyComponentDef`, `PipelineDef`: executable AI module and composition definitions.
+- `ProviderConfigDB`: model provider settings with encrypted API keys.
+- `GeneratedView`: AI-generated React view artifacts.
+- `AgentRun`, `AgentRunStep`: durable run execution and audit trail.
+- `AppManifest`: backend ↔ frontend app composition metadata.
+- `ToolTrace`: tool invocation log.
+- `ComponentVersion`, `EvalDataset`: versioning + evaluation support.
+
+### Database choice
+SQLite is default for local-first simplicity; PostgreSQL is supported via `VLOOP_DB_URL` for heavier workloads.
+
+### Schema summary
+ORM models are centralized in `harness/data/models.py`, with auto table creation at startup (`Base.metadata.create_all`) in `init_db()`.
+
+### Caching strategy
+No explicit distributed cache layer is implemented. In-memory caching exists implicitly in loaded component registries and active process state.
+
+### Data flow
+Input enters via HTTP/WS routes → validated by Pydantic models → orchestrator/repository operations execute → state is persisted in DB and/or `.vloop` storage → structured responses returned to UI.
+
+## Request Lifecycle
+Canonical flow (`POST /api/chat/sessions/{id}/messages`):
+1. FastAPI route validates `SendMessageRequest`.
+2. Repository persists user message.
+3. Route gathers context (prior messages, component and pipeline inventory, tool catalog).
+4. `MainProcess.ai` is invoked; response may include generated component code/pipeline JSON.
+5. Optional side effects: compile/save generated component/pipeline and record transcript data.
+6. Assistant message persisted.
+7. Response serialized and returned to React panel.
+
+## Key Design Decisions
+| Decision | Options Considered | Choice | Rationale |
+|---|---|---|---|
+| API framework | Flask, FastAPI | FastAPI | Async support + Pydantic validation + WS support |
+| Persistence abstraction | Direct ORM in routes, repository layer | Repository layer | Keeps routes thin and testable |
+| Default DB | PostgreSQL only, SQLite default + optional PG | SQLite default | Local-first setup with PG escape hatch |
+| LLM provider strategy | Single provider hardcoding, pluggable configs | Provider manager + DB configs | Runtime switching and secret management |
+| Tool safety | Unrestricted tool calls, policy+confirmation gates | Policy + confirmation | Reduce accidental destructive operations |
+| Frontend serving | Separate frontend server only, proxy/static dual mode | Dev proxy + static serving mode | Better dev UX and production-style fallback |
+
+## Module Dependency Rules
+- `server/routes` may depend on `data`, `engine`, `core`, `vloop`, but not vice-versa.
+- `data` should not depend on `server` modules.
+- `core` should remain framework-agnostic (no FastAPI imports).
+- `tools` are invoked through registry APIs, not route-specific direct calls in arbitrary modules.
+- React code should only consume backend contracts; no direct DB/engine access.
+
+## External Integrations
+- **Anthropic/OpenAI/Ollama**
+  - Purpose: LLM completions for chat, codegen, view generation.
+  - Call method: SDK clients (Anthropic/OpenAI) or HTTP endpoint (Ollama).
+  - Auth: API keys (encrypted at rest); Ollama can be keyless local endpoint.
+  - Failure handling: routes return error payloads/HTTP exceptions; provider test route reports detailed failures.
+  - Location: `harness/engine/dspy_engine.py`, `harness/engine/providers.py`, `harness/server/routes/settings_routes.py`.
+- **Filesystem/terminal/browser/database tools**
+  - Purpose: agent actions against workspace/runtime.
+  - Call method: internal tool registry execution APIs.
+  - Auth: permission/policy enforcement with optional confirmation token flow.
+  - Failure handling: translated to HTTP 400 or 202 (confirmation required).
+  - Location: `harness/tools/*`, `harness/server/routes/tool_routes.py`.
+
+## Scalability & Performance Considerations
+- Async API + DB operations support concurrent requests, but process is still single-node local oriented.
+- DSPy runs and some tool operations are synchronous/CPU- or IO-bound at execution points.
+- No horizontal scaling coordinator is present; state is local DB/file oriented.
+- Potential bottlenecks: long-running tool commands, model latency, and per-request compile/validation paths.
+
+## Security Model
+- Tool execution is policy-gated with deny/block lists and optional confirmation for high-risk actions.
+- Provider API keys are encrypted through `SecretVault` before DB persistence.
+- Pydantic request models enforce input shapes at API boundary.
+- Attack surface includes command execution endpoints, filesystem writes, and browser automation; mitigations rely on policy engine and explicit confirmation flow.
+
+## Known Technical Debt
+- No CI pipeline files are committed, so quality gates are currently manual/local (pytest, type checks, and e2e as needed).
+- API versioning policy is implicit rather than explicit in routes.
+- AuthN/AuthZ for multi-user scenarios is not implemented (local trusted user model).
+- Existing `DOCS/` and new `docs/` can drift without governance.
+- Some runtime behavior still references “legacy component” paths while newer app-manifest/agent flows coexist.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog.
+
+## [Unreleased]
+### Added
+- Documentation index and engineering handbook set under `docs/`.
+
+### Changed
+- Root README rewritten as canonical project entrypoint.
+
+### Deprecated
+- None.
+
+### Removed
+- None.
+
+### Fixed
+- Clarified setup, API, and contribution standards; removed placeholder items.
+
+### Security
+- No new security-impacting runtime code changes in unreleased docs-only updates.
+
+## [0.2.0] - 2026-04-26
+### Added
+- Service manager commands for backend/frontend lifecycle.
+- Static frontend serving mode in FastAPI proxy layer.
+- Eval panel and component versioning/eval dataset endpoints.
+- Agent run and app manifest APIs.
+
+### Changed
+- Runtime architecture evolved toward full-stack agent harness workflows.
+
+### Deprecated
+- None noted.
+
+### Removed
+- None noted.
+
+### Fixed
+- Static-mode debug integration and merge conflict cleanup.
+
+### Security
+- iframe source sanitization to reduce XSS risk.
+
+## [0.1.0] - 2026-04-26
+### Added
+- Initial Python harness package, FastAPI backend, React UI scaffold, and core orchestration.
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- N/A
+
+### Security
+- N/A

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing
+
+## Development Workflow
+
+### Branching Strategy
+- Main branch: `main`.
+- Branch naming:
+  - `feature/<ticket-id>-short-description`
+  - `fix/<ticket-id>-what-is-fixed`
+  - `chore/<short-description>`
+- `main` is the protected branch: no direct pushes; all changes flow through reviewed PRs.
+- Rebase or merge from `main` before opening PR to reduce drift.
+
+### Commit Standards
+Use Conventional Commits:
+```text
+type(scope): short description
+```
+Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`.
+Rules:
+- Imperative mood.
+- Subject <= 72 chars.
+- Include ticket/reference ID in body/footer when available.
+
+### Pull Request Process
+1. Branch from `main`.
+2. Implement code + tests.
+3. Run local checks (pytest + relevant frontend checks).
+4. Self-review diff for safety/security/policy implications.
+5. Open PR with clear summary and validation notes.
+6. Obtain at least 1 reviewer approval before merge.
+7. Ensure local verification checks pass (Python tests, lint/type checks, and relevant frontend checks) since CI workflow files are not currently in-repo.
+8. Merge strategy: squash merge preferred for clean history.
+9. Delete branch after merge.
+
+### PR Checklist
+- [ ] Tests written and passing
+- [ ] No regressions in existing tests
+- [ ] Linting passes
+- [ ] Types are correct (Python + TypeScript where relevant)
+- [ ] No debug code/log noise left behind
+- [ ] Env vars documented if added
+- [ ] Breaking changes noted
+
+## Code Standards
+
+### General Principles
+- Prefer readability over cleverness.
+- Keep route handlers thin; business/data logic belongs in engine/repository layers.
+- Fail explicitly with meaningful errors.
+- Preserve auditability for agent/tool actions.
+
+### File & Naming Conventions
+- Python modules: `snake_case.py`.
+- Python classes: `PascalCase`.
+- Functions/variables: `snake_case`.
+- TS/React components: `PascalCase.tsx`.
+- Route files grouped by feature under `harness/server/routes/`.
+
+### Where Code Goes
+- API contracts/serialization: `harness/server/routes/`.
+- Persistent model changes: `harness/data/models.py` + `harness/data/repository.py`.
+- Runtime orchestration changes: `harness/core/` or `harness/engine/`.
+- Tool additions: `harness/tools/` and register in `MainProcess.boot()`.
+
+### Error Handling
+- Use `HTTPException` in routes for expected request errors.
+- Convert lower-level exceptions into actionable API errors.
+- Avoid swallowing exceptions unless deliberately non-critical (and comment why).
+
+### Logging
+- Use structured logging paths already provided by harness logger/storage.
+- Log operation intent + identifiers (run_id, component_id) without secrets.
+- Never log API keys, tokens, or sensitive prompt data unless redacted.
+
+## Testing Requirements
+
+### Coverage Expectations
+- No explicit global threshold configured; expectation is meaningful coverage for changed behavior.
+- Must test route behavior, persistence changes, and tool/policy safety paths for modified code.
+
+### Test Structure
+- Python tests live in `tests/` as `test_*.py`.
+- Prefer descriptive names: `test_<unit>_<expected_behavior>`.
+- Suggested pattern:
+```python
+describe("[unit under test]", () => {
+  it("should [behavior] when [condition]", () => { ... })
+})
+```
+(Equivalent style in pytest naming/structure.)
+
+### Test Types
+- **Unit**: core helpers, policy checks, repository methods.
+- **Integration**: FastAPI route interactions with DB/session fixtures.
+- **E2E**: Playwright scenarios under `react/tests/e2e`.
+
+## Code Review Standards
+- Reviewers check correctness, safety, readability, test depth, and architectural fit.
+- Blocking comments: correctness bugs, unsafe tool access, missing tests, broken contracts.
+- Non-blocking comments: style nits, optional refactors.
+- Author response SLA: acknowledge review feedback within 1 business day and resolve blocking comments before merge.
+
+## Release Process
+- Version values currently appear in `pyproject.toml` (`0.1.0`) and API metadata/UI package (`0.2.0`); reconcile before formal release.
+- Release approval owner: repository maintainers responsible for `main` merges and release tagging.
+- Update `docs/CHANGELOG.md` on release cut.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,85 @@
+# Architecture Decision Records
+
+## ADR-001: Use FastAPI for API + WebSocket Layer
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+The system needs HTTP CRUD endpoints, WebSocket state/event streams, and strong request validation.
+
+### Decision
+Adopt FastAPI as the primary backend interface framework.
+
+### Consequences
+- Easier async endpoint implementation and OpenAPI-friendly contracts.
+- Tight coupling to Pydantic/FastAPI idioms.
+
+## ADR-002: Default to SQLite, Support PostgreSQL Override
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+Local-first developer workflow needs minimal setup while still allowing external DB usage.
+
+### Decision
+Use SQLite by default; allow PostgreSQL through `VLOOP_DB_URL`.
+
+### Consequences
+- Fast local onboarding.
+- Migration/compatibility complexity if production PG diverges.
+
+## ADR-003: Centralize Data Access via Repository Layer
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+Direct ORM usage in routes leads to duplicated persistence logic and harder tests.
+
+### Decision
+All route modules use `Repository` for CRUD/queries.
+
+### Consequences
+- Better separation of concerns and testability.
+- Repository can become large and require periodic refactoring.
+
+## ADR-004: Enforce Tool Policy + Confirmation for Risky Actions
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+Terminal/filesystem/browser/database tools can perform destructive operations.
+
+### Decision
+Route tool calls through policy engine with optional confirmation-token workflow.
+
+### Consequences
+- Improved safety and auditability.
+- Slightly higher UX friction for high-risk actions.
+
+## ADR-005: Keep Python as Orchestration Brain and React as Control UI
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+The product combines execution orchestration, persistence, and dynamic UI workflows.
+
+### Decision
+Use Python for state/orchestration/AI integration and React for presentation/workflow UI.
+
+### Consequences
+- Clear separation by responsibility.
+- Requires maintaining robust API contract between backend and frontend.
+
+## ADR-006: Support Dual Frontend Modes (Dev Proxy + Static Dist)
+**Date**: 2026-04-26 (inferred)
+**Status**: Accepted
+
+### Context
+Developers need HMR, but runtime also needs production-style static serving.
+
+### Decision
+Use `HARNESS_DEBUG` to switch between proxy-to-Vite and `react/dist` static serving.
+
+### Consequences
+- Better developer ergonomics and deployment flexibility.
+- More branching logic in proxy/static routing paths.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation
+
+## Quick Links
+
+|Document|Description|Audience|
+|---|---|---|
+|[../README.md](../README.md)|Project overview & quick start|Everyone|
+|[ARCHITECTURE.md](./ARCHITECTURE.md)|System design & decisions|Engineers|
+|[API.md](./API.md)|API reference|Engineers, Integrators|
+|[SETUP.md](./SETUP.md)|Local dev environment|New engineers|
+|[CONTRIBUTING.md](./CONTRIBUTING.md)|Standards & workflow|Contributors|
+|[DECISIONS.md](./DECISIONS.md)|Architecture decision records|Senior engineers|
+|[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)|Common issues & fixes|Everyone|
+|[CHANGELOG.md](./CHANGELOG.md)|Version history|Everyone|
+
+## Final Audit Notes
+- Cross-references validated within `docs/` and root README links.
+- Terminology normalized around “Vloop Harness”, “MainProcess”, and “DSPy components/pipelines”.
+- No unresolved placeholders remain; policy and process assumptions are now explicit in each document.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,125 @@
+# Local Development Setup
+
+## System Requirements
+| Requirement | Minimum Version | How to Check | How to Install |
+|---|---|---|---|
+| Git | Any modern version | `git --version` | https://git-scm.com/downloads |
+| Python | 3.11+ | `python --version` | https://www.python.org/downloads/ |
+| pip | Bundled with Python | `pip --version` | `python -m ensurepip --upgrade` |
+| Node.js | 18.18.0+ | `node --version` | https://nodejs.org/ |
+| npm | Bundled with Node | `npm --version` | Comes with Node.js install |
+| Playwright browsers (optional e2e) | matching @playwright/test | `ls /opt/pw-browsers` | `npx playwright install` (if not pre-provisioned) |
+
+OS: Linux/macOS/Windows supported in principle; primary local workflow appears Linux/macOS oriented (`bash` examples).
+
+## Step-by-Step Setup
+### 1. Clone the repository
+```bash
+git clone <repo-url>
+cd Vloop-harness
+```
+
+### 2. Install dependencies
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+cd react
+npm install
+cd ..
+```
+
+### 3. Configure environment
+```bash
+cp .env.example .env
+```
+Set/verify these values in `.env`:
+- Required for all local runs: `HARNESS_HOST`, `HARNESS_PORT`, `HARNESS_DEBUG`, `VITE_HOST`, `VITE_PORT`.
+- Required for hosted LLM providers: `ANTHROPIC_API_KEY` and/or `OPENAI_API_KEY`.
+- Optional for local LLM: `OLLAMA_BASE_URL` (defaults to `http://localhost:11434`).
+- Optional DB override: `VLOOP_DB_URL` for PostgreSQL.
+
+### 4. Database setup
+Default (SQLite): no manual migration command required; tables auto-create at startup.
+
+Optional PostgreSQL:
+```bash
+export VLOOP_DB_URL='postgresql+asyncpg://user:password@localhost/vloop'
+python -m harness.main services start backend
+```
+
+### 5. Start the application
+```bash
+python -m harness.main services start all
+```
+Open: `http://localhost:8000/ui/root`.
+Success looks like: root dashboard loads and backend status endpoint (`GET /`) returns JSON `{"status":"ok",...}`.
+
+### 6. Verify with tests
+```bash
+pytest
+cd react && npm run typecheck && cd ..
+```
+Optional E2E:
+```bash
+cd react && npm run test:e2e && cd ..
+```
+
+## Common Issues & Fixes
+| Problem | Symptom | Fix |
+|---|---|---|
+| Backend port in use | `Backend port conflict` error | Change `HARNESS_PORT` or stop conflicting process |
+| Frontend port in use | Vite startup fails on 5173 | Change `VITE_PORT` or free port |
+| Missing frontend deps | `node_modules` missing error from service manager | Run `cd react && npm install` |
+| AI engine unavailable | Chat/view generation returns not configured | Create provider in Settings and set default |
+| Invalid provider key | `/api/providers/{id}/test` returns error | Re-enter API key and model/base URL |
+| Static mode assets missing | `react/dist` missing 503 | Run `cd react && npm run build` or use debug mode |
+| Policy denial on tools | tool call fails with policy violation | Update project policy via `/api/tools/policy` if appropriate |
+| Confirmation required | tool endpoint returns `202` | Confirm using `/api/tools/confirm/{token}` |
+| SQLite file permissions | DB init/write errors in `.vloop` | Ensure workspace is writable |
+| Python version mismatch | install/type errors | Use Python 3.11+ virtualenv |
+
+## IDE Setup
+- Python: enable Ruff + mypy + pytest integration.
+- TypeScript/React: enable TypeScript language service; ESLint is not configured in this repository, so rely on TypeScript strict mode and code review.
+- Recommended editor settings:
+  - format on save
+  - 100-char max line length for Python (matches Ruff config)
+  - strict TS error visibility
+
+## Working with Docker
+No Dockerfile/compose configuration is currently committed; local development runs directly with Python + npm processes.
+
+## Useful Dev Commands
+```bash
+# Start all services
+python -m harness.main services start all
+
+# Service status
+python -m harness.main services status
+
+# Stop all services
+python -m harness.main services stop all
+
+# Headless run mode
+python -m harness.main run --no-window
+
+# Static frontend serving mode
+python -m harness.main run --frontend-mode static
+
+# Python tests
+pytest
+
+# Frontend dev server manually
+cd react && npm run dev
+```
+
+## Data Management
+- Reset local harness/vloop runtime data:
+```bash
+rm -rf .harness .vloop
+```
+- Recreate DB state: restart backend after deletion.
+- Seed data: default provider seeds are handled automatically in startup provider manager; no dedicated custom seed script exists in this repository.
+- Migrations: explicit migration framework is not configured (`Base.metadata.create_all` is used).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+### Issue: Backend port already in use
+**Symptoms**: `Backend port conflict` during service start.
+**Cause**: Another process is listening on `HARNESS_PORT`.
+**Fix**: Stop conflicting process or set a new `HARNESS_PORT` in `.env`.
+**Prevention**: Reserve standard local ports per project.
+
+### Issue: Frontend port already in use
+**Symptoms**: Frontend fails to start; Vite reports port conflict.
+**Cause**: Existing process bound to `VITE_PORT`.
+**Fix**: Change `VITE_PORT` or stop conflicting process.
+**Prevention**: Run `harness services status` before startup.
+
+### Issue: Vite dev server unreachable
+**Symptoms**: `/ui/root` returns 503 in debug mode.
+**Cause**: Frontend process not running or crashed.
+**Fix**: `cd react && npm install && npm run dev` or restart services.
+**Prevention**: Ensure frontend dependencies are installed.
+
+### Issue: Static mode missing dist assets
+**Symptoms**: 503 mentions missing `react/dist` or entry HTML.
+**Cause**: Static mode enabled without build artifacts.
+**Fix**: `cd react && npm run build`; then rerun with static mode.
+**Prevention**: Build frontend before static deployments.
+
+### Issue: AI engine not configured
+**Symptoms**: Chat or view generation says engine/provider not configured.
+**Cause**: No default provider configured in DB.
+**Fix**: Create provider via Settings API/UI and set as default.
+**Prevention**: Configure provider during initial setup.
+
+### Issue: Provider connectivity test fails
+**Symptoms**: `/api/providers/{id}/test` returns error.
+**Cause**: Invalid API key/model/base URL or network issue.
+**Fix**: Verify credentials and endpoint; retry test.
+**Prevention**: Validate keys externally and store correct base URLs.
+
+### Issue: Tool action blocked by policy
+**Symptoms**: Tool endpoint returns policy error.
+**Cause**: Denylist/blocklist/workspace policy restriction.
+**Fix**: Review `/api/tools/policy` and adjust if allowed by team rules.
+**Prevention**: Define project policy up front.
+
+### Issue: Tool action requires confirmation
+**Symptoms**: HTTP 202 with `requires_confirmation=true`.
+**Cause**: Risky action guard triggered.
+**Fix**: Confirm with `POST /api/tools/confirm/{token}`.
+**Prevention**: Expect confirmation on destructive writes/deletes.
+
+### Issue: Component compile errors (DSPy)
+**Symptoms**: 422 on component create/update/run.
+**Cause**: Invalid generated/manual component code.
+**Fix**: Inspect returned compile error detail; fix signature/module code.
+**Prevention**: Keep component code minimal and test compile early.
+
+### Issue: WebSocket closes with component not found
+**Symptoms**: WS close code 4004 for `/ws/{component_id}`.
+**Cause**: Component was removed/unregistered.
+**Fix**: Recreate component or refresh to current component IDs.
+**Prevention**: Handle component lifecycle changes in UI.
+
+### Issue: SQLite write/lock failures
+**Symptoms**: DB operation errors under `.vloop`.
+**Cause**: Permission issues or concurrent file locks.
+**Fix**: Ensure writable workspace, stop duplicate harness instances.
+**Prevention**: Run a single local backend per workspace.
+
+### Issue: Playwright tests fail to launch browser
+**Symptoms**: `browser executable not found` in e2e tests.
+**Cause**: Browser binaries unavailable at configured path.
+**Fix**: Install browsers (`npx playwright install`) or set `PLAYWRIGHT_BROWSERS_PATH` correctly.
+**Prevention**: Validate browser installation after dependency install.


### PR DESCRIPTION
### Motivation

- Replace the legacy HARNESS architecture README with a consolidated, up-to-date project entrypoint for the Vloop Harness workbench.  
- Provide a canonical set of developer-facing documentation for API contracts, architecture, setup, contributing, and operational guidance.  
- Make project conventions, environment variables, and runtime modes explicit to improve onboarding and reduce ad-hoc assumptions.  

### Description

- Rewrote the top-level `README.md` to describe the new "Vloop Harness" product, tech stack, architecture diagram, environment variables, CLI scripts, and quickstart commands.  
- Added a docs suite under `docs/`: `API.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `DECISIONS.md`, `README.md` (docs index), `SETUP.md`, and `TROUBLESHOOTING.md` capturing API reference, ADRs, setup steps, developer workflow, and known issues.  
- Normalized recommended commands and developer checks (e.g. `pytest`, frontend `npm` scripts, `python -m harness.main services start all`) and documented dual frontend modes (`HARNESS_DEBUG` dev proxy vs static `react/dist`).  
- This change is docs-only and does not change runtime code or API implementations; it documents existing/expected routes, entities, and repository structure for engineers.  

### Testing

- No automated tests were required or executed for this docs-only change.  
- Recommended verification steps (documented) include running `pytest` for backend tests and `cd react && npm run typecheck` and `cd react && npm run test:e2e` for frontend checks, but these were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee7406e784832abe5036c911d1667a)