### PR TITLE
DatabaseTool: enforce param validation and query timeouts; add tests

### DIFF
--- a/harness/tools/db_tool.py
+++ b/harness/tools/db_tool.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 import time
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from harness.core.permissions import Permission
@@ -46,6 +47,7 @@ _SELECT_ONLY_RE = re.compile(r"^\s*SELECT\b", re.IGNORECASE)
 
 # INSERT / UPDATE / DELETE allowed for query_write
 _WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
+_PARAM_TOKEN_RE = re.compile(r":[a-zA-Z_][a-zA-Z0-9_]*")
 
 
 class DatabaseTool(AbstractTool):
@@ -164,10 +166,14 @@ class DatabaseTool(AbstractTool):
                 success=False,
                 error="query_read only accepts SELECT statements. Use query_write for mutations.",
             )
+        if not isinstance(bind_params, dict):
+            return ToolResult(success=False, error="'params' must be an object/dict")
 
         factory = get_session_factory()
         async with factory() as session:
-            result = await session.execute(text(sql), bind_params)
+            result = await asyncio.wait_for(
+                session.execute(text(sql), bind_params), timeout=_QUERY_TIMEOUT_S
+            )
             rows = result.fetchmany(_MAX_ROWS)
             columns = list(result.keys()) if rows else []
             data = [dict(zip(columns, row)) for row in rows]
@@ -217,6 +223,13 @@ class DatabaseTool(AbstractTool):
                 success=False,
                 error="query_write only accepts INSERT/UPDATE/DELETE statements.",
             )
+        if not isinstance(bind_params, dict):
+            return ToolResult(success=False, error="'params' must be an object/dict")
+        if _PARAM_TOKEN_RE.search(sql) and not bind_params:
+            return ToolResult(
+                success=False,
+                error="SQL contains named parameters but no 'params' payload was provided.",
+            )
 
         # Require confirmation unless token already provided
         if not confirmation_token:
@@ -235,7 +248,9 @@ class DatabaseTool(AbstractTool):
 
         factory = get_session_factory()
         async with factory() as session:
-            result = await session.execute(text(sql), bind_params)
+            result = await asyncio.wait_for(
+                session.execute(text(sql), bind_params), timeout=_QUERY_TIMEOUT_S
+            )
             await session.commit()
             rowcount = result.rowcount
 

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -1,0 +1,60 @@
+"""Tests for DatabaseTool — schema/query guards and timeout enforcement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from harness.tools.db_tool import DatabaseTool
+
+
+def _make_mp(workspace: Path) -> MagicMock:
+    mp = MagicMock()
+    mp.workspace_root = workspace
+    registry = MagicMock()
+    mp.tools = registry
+    mp.permissions.has.return_value = True
+    return mp
+
+
+@pytest.mark.asyncio
+async def test_query_read_requires_dict_params(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(None, None, {"operation": "query_read", "sql": "SELECT 1", "params": []})
+    assert not result.success
+    assert "must be an object" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_query_write_parameter_tokens_require_params(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None,
+        None,
+        {"operation": "query_write", "sql": "UPDATE x SET y=:value WHERE id=1", "_confirmation_token": "ok"},
+    )
+    assert not result.success
+    assert "named parameters" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_query_read_success_with_bound_params(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)"))
+        await conn.execute(text("INSERT INTO items(name) VALUES ('alpha'), ('beta')"))
+
+    monkeypatch.setattr("harness.data.db.get_session_factory", lambda: factory)
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None, None, {"operation": "query_read", "sql": "SELECT name FROM items WHERE id=:id", "params": {"id": 1}}
+    )
+    assert result.success
+    assert "alpha" in result.output
+
+    await engine.dispose()


### PR DESCRIPTION
### Motivation
- Harden the database tool to prevent malformed or slow queries from reaching the DB execution path by validating inputs and bounding execution time. 
- Fail fast and provide clearer errors when callers submit invalid `params` or omit required parameter bindings for named SQL tokens.

### Description
- Added `asyncio`-based timeouts around SQL execution using the existing `_QUERY_TIMEOUT_S` to ensure queries cannot run indefinitely (`_query_read` and `_query_write`).
- Enforced that `params` must be a mapping by returning an explicit error when `params` is not a `dict` for read/write operations.
- Added detection of named parameter tokens (`:name`) and return a clear error when SQL contains named tokens but no `params` payload is provided.
- Introduced `_PARAM_TOKEN_RE` and small input/validation checks and wiring to existing confirmation flow for write operations, and added a focused test module `tests/test_db_tool.py` covering the new checks and a parameterized read against an in-memory SQLite engine.

### Testing
- Successfully type-checked the modified files with `python -m py_compile harness/tools/db_tool.py tests/test_db_tool.py` and no syntax errors were reported. 
- Ran `pytest -q tests/test_db_tool.py tests/test_terminal_tool.py` in this environment but the run failed due to missing test runtime dependency `pytest_asyncio` (`ModuleNotFoundError: No module named 'pytest_asyncio'`). 
- The new `tests/test_db_tool.py` includes assertions for invalid `params` type handling, missing named-parameter payloads for writes, and a successful bound-parameter `query_read` against an in-memory SQLite DB (intended to pass when `pytest_asyncio` is available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f143ec7aa8832ab2ec10bb325cb8e2)