### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass vulnerability in BrowserTool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-11 - SSRF Vulnerability in BrowserTool Prefix Matching
+**Vulnerability:** The `BrowserTool`'s origin verification allowed SSRF bypasses because it used `url.startswith(prefix)` to check against allowed origins. An allowed prefix like `http://localhost` could be bypassed by a URL like `http://localhost.evil.com`.
+**Learning:** Naive string prefix matching is inherently insecure for URL validation. It does not enforce domain or path boundaries correctly.
+**Prevention:** Always use proper URL parsing utilities like `urllib.parse.urlparse` and independently validate the scheme, hostname, port, and path to ensure exact matches.

--- a/harness/tools/browser_tool.py
+++ b/harness/tools/browser_tool.py
@@ -113,7 +113,50 @@ class BrowserTool(AbstractTool):
         except Exception:
             pass
 
-        if not any(url.startswith(prefix) for prefix in allowed_prefixes):
+        from urllib.parse import urlparse
+
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname or ""
+            scheme = parsed.scheme
+            port = parsed.port
+
+            allowed = False
+            for prefix in allowed_prefixes:
+                try:
+                    p_prefix = urlparse(prefix)
+                    p_hostname = p_prefix.hostname or ""
+                    p_scheme = p_prefix.scheme
+                    p_port = p_prefix.port
+
+                    # If the prefix does not specify a port, we allow any port (which maintains the behavior of original startswith)
+                    # Alternatively, if prefix starts with http/https but specifies no port, we only check hostname and scheme.
+                    # Wait, startswith("http://localhost") allowed "http://localhost:8080".
+                    # It also allowed "http://localhost/path"
+                    # However, if allowed prefix has a path like "http://localhost/secure", startswith would require the path.
+
+                    # More robust matching:
+                    # Construct normalized base of the prefix to see if the URL starts with it,
+                    # BUT enforce that the hostname matches exactly.
+
+                    if scheme == p_scheme and hostname == p_hostname:
+                        # Check port
+                        if p_port is not None and port != p_port:
+                            continue
+
+                        # Check path prefix
+                        p_path = p_prefix.path
+                        if p_path and not parsed.path.startswith(p_path):
+                            continue
+
+                        allowed = True
+                        break
+                except Exception:
+                    pass
+        except Exception:
+            allowed = False
+
+        if not allowed:
             raise WorkspaceEscape(
                 f"URL {url!r} is not in the browser allowed-origins list. "
                 "Configure browser_allowed_origins in your policy.json to allow it."


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `BrowserTool`'s origin verification allowed SSRF bypasses because it used `url.startswith(prefix)` to check against allowed origins. An allowed prefix like `http://localhost` could be bypassed by a URL like `http://localhost.evil.com`.
🎯 Impact: An attacker could bypass workspace boundary policies to navigate the headless browser to arbitrary unapproved URLs that just happen to share a prefix with an approved origin.
🔧 Fix: Updated `_check_url` to use `urllib.parse.urlparse` to independently validate the scheme, hostname, port, and path, ensuring robust boundary verification.
✅ Verification: Tested via the Python test suite, specifically adding unit tests during development to verify both standard usage and SSRF bypass attempts.

---
*PR created automatically by Jules for task [17813517905068790224](https://jules.google.com/task/17813517905068790224) started by @Psyborgs-git*