### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL injection/bypass via AST parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - [Fix XSS Vulnerability in Injector]
+**Vulnerability:** In `harness/server/injector.py`, user-controlled state (`initial_state`) was being serialized via `json.dumps()` and injected directly into an inline `<script>` tag within the HTML response. If a string in `initial_state` contained `</script>`, it could prematurely close the script tag, leading to a Cross-Site Scripting (XSS) vulnerability.
+**Learning:** `json.dumps` natively escapes many characters but doesn't escape HTML-specific ones like `<`, `>`, and `&`. Injecting raw JSON directly into HTML (even inside a `<script>` tag) is dangerous and breaks out of the context.
+**Prevention:** Always replace sensitive HTML characters (`<`, `>`, `&`) with their unicode escapes (`\u003c`, `\u003e`, `\u0026`) after serialization when embedding JSON in a `<script>` tag.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-01 - Audit Logging for Tool Execution
+**Vulnerability:** Missing audit logs for tool executions. Tool actions (like filesystem reads/writes, terminal commands) were executing without a centralized trace record, meaning potentially destructive actions lacked accountability or observability.
+**Learning:** The database repository already had a `ToolTrace` model and `record_tool_trace` function, and a robust `redact_secrets` utility existed, but the integration in the central tool dispatcher (`ToolRegistry.execute`) was missing.
+**Prevention:** Always ensure that sensitive and potentially destructive actions triggered by users or AI agents are recorded in an audit log with robust secret redaction.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** Missing audit logs for tool executions. Tool actions (like filesystem reads/writes, terminal commands) were executing without a centralized trace record, meaning potentially destructive actions lacked accountability or observability.
 **Learning:** The database repository already had a `ToolTrace` model and `record_tool_trace` function, and a robust `redact_secrets` utility existed, but the integration in the central tool dispatcher (`ToolRegistry.execute`) was missing.
 **Prevention:** Always ensure that sensitive and potentially destructive actions triggered by users or AI agents are recorded in an audit log with robust secret redaction.
+## 2025-02-23 - [Fix SQL Injection Bypass via AST Parsing]
+**Vulnerability:** The `DatabaseTool` used regexes like `^\s*SELECT\b` and `^\s*(INSERT|UPDATE|DELETE)\b` to validate SQL queries for `query_read` and `query_write` operations. This allowed bypassing validation via statement chaining (e.g. `WITH cte AS (SELECT 1) SELECT * FROM cte; UPDATE users SET role='admin'`).
+**Learning:** Regex is inherently unsuited for robust SQL query validation because it cannot accurately parse statement boundaries or understand complex structures like CTEs.
+**Prevention:** Always use a proper Abstract Syntax Tree (AST) parser like `sqlglot` to parse and validate every statement in a given SQL query block instead of using naive regex.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-11 - SSRF Vulnerability in BrowserTool Prefix Matching
+**Vulnerability:** The `BrowserTool`'s origin verification allowed SSRF bypasses because it used `url.startswith(prefix)` to check against allowed origins. An allowed prefix like `http://localhost` could be bypassed by a URL like `http://localhost.evil.com`.
+**Learning:** Naive string prefix matching is inherently insecure for URL validation. It does not enforce domain or path boundaries correctly.
+**Prevention:** Always use proper URL parsing utilities like `urllib.parse.urlparse` and independently validate the scheme, hostname, port, and path to ensure exact matches.

--- a/harness/server/injector.py
+++ b/harness/server/injector.py
@@ -30,9 +30,15 @@ def inject_harness_vars(
         "INITIAL_STATE": initial_state,
         "PERMISSIONS": permissions,
     }
+    safe_payload = (
+        json.dumps(payload, indent=2)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
     script = (
         "<script>\n"
-        f"  window.__HARNESS__ = {json.dumps(payload, indent=2)};\n"
+        f"  window.__HARNESS__ = {safe_payload};\n"
         "</script>\n"
     )
 

--- a/harness/tools/browser_tool.py
+++ b/harness/tools/browser_tool.py
@@ -113,7 +113,50 @@ class BrowserTool(AbstractTool):
         except Exception:
             pass
 
-        if not any(url.startswith(prefix) for prefix in allowed_prefixes):
+        from urllib.parse import urlparse
+
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname or ""
+            scheme = parsed.scheme
+            port = parsed.port
+
+            allowed = False
+            for prefix in allowed_prefixes:
+                try:
+                    p_prefix = urlparse(prefix)
+                    p_hostname = p_prefix.hostname or ""
+                    p_scheme = p_prefix.scheme
+                    p_port = p_prefix.port
+
+                    # If the prefix does not specify a port, we allow any port (which maintains the behavior of original startswith)
+                    # Alternatively, if prefix starts with http/https but specifies no port, we only check hostname and scheme.
+                    # Wait, startswith("http://localhost") allowed "http://localhost:8080".
+                    # It also allowed "http://localhost/path"
+                    # However, if allowed prefix has a path like "http://localhost/secure", startswith would require the path.
+
+                    # More robust matching:
+                    # Construct normalized base of the prefix to see if the URL starts with it,
+                    # BUT enforce that the hostname matches exactly.
+
+                    if scheme == p_scheme and hostname == p_hostname:
+                        # Check port
+                        if p_port is not None and port != p_port:
+                            continue
+
+                        # Check path prefix
+                        p_path = p_prefix.path
+                        if p_path and not parsed.path.startswith(p_path):
+                            continue
+
+                        allowed = True
+                        break
+                except Exception:
+                    pass
+        except Exception:
+            allowed = False
+
+        if not allowed:
             raise WorkspaceEscape(
                 f"URL {url!r} is not in the browser allowed-origins list. "
                 "Configure browser_allowed_origins in your policy.json to allow it."

--- a/harness/tools/db_tool.py
+++ b/harness/tools/db_tool.py
@@ -26,6 +26,9 @@ import time
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+import sqlglot
+import sqlglot.expressions as exp
+
 from harness.core.permissions import Permission
 from harness.tools.base_tool import AbstractTool, ToolResult
 from harness.tools.exceptions import ConfirmationRequired
@@ -36,17 +39,6 @@ if TYPE_CHECKING:
 _MAX_ROWS = 500
 _QUERY_TIMEOUT_S = 10
 
-# Statements that are always blocked
-_PERMANENT_BLOCK_RE = re.compile(
-    r"\b(DROP\s+TABLE|DROP\s+DATABASE|TRUNCATE|ALTER\s+TABLE)\b",
-    re.IGNORECASE,
-)
-
-# Only SELECT is allowed for query_read
-_SELECT_ONLY_RE = re.compile(r"^\s*SELECT\b", re.IGNORECASE)
-
-# INSERT / UPDATE / DELETE allowed for query_write
-_WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
 _PARAM_TOKEN_RE = re.compile(r":[a-zA-Z_][a-zA-Z0-9_]*")
 
 
@@ -154,18 +146,20 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
+        try:
+            statements = sqlglot.parse(sql)
+            if not statements:
+                return ToolResult(success=False, error="No SQL statements found.")
 
-        if not _SELECT_ONLY_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_read only accepts SELECT statements. Use query_write for mutations.",
-            )
+            for stmt in statements:
+                if not isinstance(stmt, (exp.Select, exp.Union)):
+                    return ToolResult(
+                        success=False,
+                        error="query_read only accepts read-only SELECT/UNION statements. Use query_write for mutations.",
+                    )
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Failed to parse SQL: {exc}")
+
         if not isinstance(bind_params, dict):
             return ToolResult(success=False, error="'params' must be an object/dict")
 
@@ -211,18 +205,26 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
+        try:
+            statements = sqlglot.parse(sql)
+            if not statements:
+                return ToolResult(success=False, error="No SQL statements found.")
 
-        if not _WRITE_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_write only accepts INSERT/UPDATE/DELETE statements.",
-            )
+            for stmt in statements:
+                if isinstance(stmt, (exp.Drop, exp.Alter, exp.Command, exp.TruncateTable)):
+                    # A basic catch for permanently blocked statements
+                    return ToolResult(
+                        success=False,
+                        error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
+                    )
+                if not isinstance(stmt, (exp.Insert, exp.Update, exp.Delete)):
+                    return ToolResult(
+                        success=False,
+                        error="query_write only accepts INSERT/UPDATE/DELETE statements.",
+                    )
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Failed to parse SQL: {exc}")
+
         if not isinstance(bind_params, dict):
             return ToolResult(success=False, error="'params' must be an object/dict")
         if _PARAM_TOKEN_RE.search(sql) and not bind_params:

--- a/harness/tools/db_tool.py
+++ b/harness/tools/db_tool.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 import time
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from harness.core.permissions import Permission
@@ -46,6 +47,7 @@ _SELECT_ONLY_RE = re.compile(r"^\s*SELECT\b", re.IGNORECASE)
 
 # INSERT / UPDATE / DELETE allowed for query_write
 _WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
+_PARAM_TOKEN_RE = re.compile(r":[a-zA-Z_][a-zA-Z0-9_]*")
 
 
 class DatabaseTool(AbstractTool):
@@ -164,10 +166,14 @@ class DatabaseTool(AbstractTool):
                 success=False,
                 error="query_read only accepts SELECT statements. Use query_write for mutations.",
             )
+        if not isinstance(bind_params, dict):
+            return ToolResult(success=False, error="'params' must be an object/dict")
 
         factory = get_session_factory()
         async with factory() as session:
-            result = await session.execute(text(sql), bind_params)
+            result = await asyncio.wait_for(
+                session.execute(text(sql), bind_params), timeout=_QUERY_TIMEOUT_S
+            )
             rows = result.fetchmany(_MAX_ROWS)
             columns = list(result.keys()) if rows else []
             data = [dict(zip(columns, row)) for row in rows]
@@ -217,6 +223,13 @@ class DatabaseTool(AbstractTool):
                 success=False,
                 error="query_write only accepts INSERT/UPDATE/DELETE statements.",
             )
+        if not isinstance(bind_params, dict):
+            return ToolResult(success=False, error="'params' must be an object/dict")
+        if _PARAM_TOKEN_RE.search(sql) and not bind_params:
+            return ToolResult(
+                success=False,
+                error="SQL contains named parameters but no 'params' payload was provided.",
+            )
 
         # Require confirmation unless token already provided
         if not confirmation_token:
@@ -235,7 +248,9 @@ class DatabaseTool(AbstractTool):
 
         factory = get_session_factory()
         async with factory() as session:
-            result = await session.execute(text(sql), bind_params)
+            result = await asyncio.wait_for(
+                session.execute(text(sql), bind_params), timeout=_QUERY_TIMEOUT_S
+            )
             await session.commit()
             rowcount = result.rowcount
 

--- a/harness/tools/registry.py
+++ b/harness/tools/registry.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from harness.tools.base_tool import AbstractTool, ToolResult
+from harness.vloop.redaction import redact_secrets
+from harness.data.db import get_session_factory
+from harness.data.repository import Repository
 
 if TYPE_CHECKING:
     from harness.core.main_process import MainProcess
@@ -45,7 +48,37 @@ class ToolRegistry:
                 success=False,
                 error=f"Unknown tool: {tool_name!r}",
             )
-        return await tool.execute(component_id, session_id, params or {})
+
+        safe_params = params or {}
+
+        # Determine token for pending confirmations if present
+        confirmation_token = safe_params.get("_confirmation_token")
+
+        # Execute the tool
+        result = await tool.execute(component_id, session_id, safe_params)
+
+        # Save trace
+        try:
+            factory = get_session_factory()
+            async with factory() as session:
+                repo = Repository(session)
+                await repo.record_tool_trace(
+                    tool_name=tool_name,
+                    inputs=redact_secrets(safe_params),
+                    outputs=redact_secrets(result.to_dict()),
+                    component_id=component_id,
+                    session_id=session_id,
+                    run_step_id=None,
+                    risk_level=tool.risk_level,
+                    confirmation_token=confirmation_token,
+                    duration_ms=result.metadata.get("duration_ms"),
+                    success=result.success,
+                )
+        except Exception:
+            # We don't want tool tracing failures to bring down the whole app
+            self._mp.logger.error(f"Failed to record tool trace for {tool_name}")
+
+        return result
 
     # ── Catalog ───────────────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "asyncpg>=0.30.0",
     "cryptography>=42.0.0",
+    "sqlglot>=30.8.0",
 
     # File watching (hot reload)
     "watchdog>=6.0.0",

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -58,3 +58,24 @@ async def test_query_read_success_with_bound_params(monkeypatch: pytest.MonkeyPa
     assert "alpha" in result.output
 
     await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_query_read_blocks_mutations(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(None, None, {"operation": "query_read", "sql": "WITH cte AS (SELECT 1) SELECT * FROM cte; UPDATE x SET y=1"})
+    assert not result.success
+    assert "query_read only accepts read-only SELECT/UNION statements" in (result.error or "")
+
+@pytest.mark.asyncio
+async def test_query_write_blocks_drop(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(None, None, {"operation": "query_write", "sql": "DROP TABLE x", "_confirmation_token": "ok"})
+    assert not result.success
+    assert "permanently blocked" in (result.error or "")
+
+@pytest.mark.asyncio
+async def test_query_write_blocks_select(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(None, None, {"operation": "query_write", "sql": "SELECT 1", "_confirmation_token": "ok"})
+    assert not result.success
+    assert "only accepts INSERT/UPDATE/DELETE" in (result.error or "")

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -1,0 +1,60 @@
+"""Tests for DatabaseTool — schema/query guards and timeout enforcement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from harness.tools.db_tool import DatabaseTool
+
+
+def _make_mp(workspace: Path) -> MagicMock:
+    mp = MagicMock()
+    mp.workspace_root = workspace
+    registry = MagicMock()
+    mp.tools = registry
+    mp.permissions.has.return_value = True
+    return mp
+
+
+@pytest.mark.asyncio
+async def test_query_read_requires_dict_params(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(None, None, {"operation": "query_read", "sql": "SELECT 1", "params": []})
+    assert not result.success
+    assert "must be an object" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_query_write_parameter_tokens_require_params(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None,
+        None,
+        {"operation": "query_write", "sql": "UPDATE x SET y=:value WHERE id=1", "_confirmation_token": "ok"},
+    )
+    assert not result.success
+    assert "named parameters" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_query_read_success_with_bound_params(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)"))
+        await conn.execute(text("INSERT INTO items(name) VALUES ('alpha'), ('beta')"))
+
+    monkeypatch.setattr("harness.data.db.get_session_factory", lambda: factory)
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None, None, {"operation": "query_read", "sql": "SELECT name FROM items WHERE id=:id", "params": {"id": 1}}
+    )
+    assert result.success
+    assert "alpha" in result.output
+
+    await engine.dispose()


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `DatabaseTool` used regexes like `^\s*SELECT\b` and `^\s*(INSERT|UPDATE|DELETE)\b` to validate SQL queries for `query_read` and `query_write` operations. This allowed bypassing validation via statement chaining (e.g. `WITH cte AS (SELECT 1) SELECT * FROM cte; UPDATE users SET role='admin'`).
🎯 **Impact:** Allowed arbitrary data mutations on read-only queries or bypassing of blocked statements.
🔧 **Fix:** Migrated away from naive regex SQL validation to robust AST parsing using `sqlglot`. We now evaluate every statement in a given SQL string to ensure that read queries contain only `SELECT` or `UNION` statements, and write queries contain only `INSERT`, `UPDATE`, or `DELETE` statements.
✅ **Verification:** Verified by unit tests added to `tests/test_db_tool.py` that explicitly test the bypassing via statement chaining.

---
*PR created automatically by Jules for task [10345818647437707968](https://jules.google.com/task/10345818647437707968) started by @Psyborgs-git*