### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection bypass in db_tool

### DIFF
--- a/harness/tools/db_tool.py
+++ b/harness/tools/db_tool.py
@@ -26,6 +26,9 @@ import time
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+import sqlglot
+from sqlglot import exp
+
 from harness.core.permissions import Permission
 from harness.tools.base_tool import AbstractTool, ToolResult
 from harness.tools.exceptions import ConfirmationRequired
@@ -154,18 +157,35 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
+        try:
+            stmts = sqlglot.parse(sql)
+            if len(stmts) != 1:
+                return ToolResult(
+                    success=False, error="query_read only accepts exactly one statement."
+                )
+            ast = stmts[0]
+            if ast is None:
+                return ToolResult(success=False, error="Failed to parse SQL statement.")
 
-        if not _SELECT_ONLY_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_read only accepts SELECT statements. Use query_write for mutations.",
-            )
+            # Root node must be a SELECT
+            if not isinstance(ast, exp.Select):
+                return ToolResult(
+                    success=False,
+                    error="query_read only accepts SELECT statements. Use query_write for mutations.",
+                )
+
+            # Block any mutations or DDL, even within CTEs
+            mutating_nodes = list(ast.find_all(
+                (exp.Delete, exp.Update, exp.Insert, exp.Drop, exp.Alter, exp.TruncateTable, exp.Command, exp.Create)
+            ))
+            if mutating_nodes:
+                return ToolResult(
+                    success=False,
+                    error="query_read only accepts SELECT statements. Use query_write for mutations.",
+                )
+        except sqlglot.errors.ParseError as exc:
+            return ToolResult(success=False, error=f"SQL parsing error: {exc}")
+
         if not isinstance(bind_params, dict):
             return ToolResult(success=False, error="'params' must be an object/dict")
 
@@ -211,18 +231,34 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
+        try:
+            stmts = sqlglot.parse(sql)
+            if len(stmts) != 1:
+                return ToolResult(
+                    success=False, error="query_write only accepts exactly one statement."
+                )
+            ast = stmts[0]
+            if ast is None:
+                return ToolResult(success=False, error="Failed to parse SQL statement.")
 
-        if not _WRITE_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_write only accepts INSERT/UPDATE/DELETE statements.",
-            )
+            # Block permanently dangerous statements (including DDL like CREATE)
+            blocked_nodes = list(ast.find_all((exp.Drop, exp.Alter, exp.TruncateTable, exp.Command, exp.Create)))
+            if blocked_nodes:
+                return ToolResult(
+                    success=False,
+                    error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER/CREATE).",
+                )
+
+            # Ensure there is at least one mutating operation
+            mutating_nodes = list(ast.find_all((exp.Insert, exp.Update, exp.Delete)))
+            if not mutating_nodes:
+                return ToolResult(
+                    success=False,
+                    error="query_write only accepts INSERT/UPDATE/DELETE statements.",
+                )
+        except sqlglot.errors.ParseError as exc:
+            return ToolResult(success=False, error=f"SQL parsing error: {exc}")
+
         if not isinstance(bind_params, dict):
             return ToolResult(success=False, error="'params' must be an object/dict")
         if _PARAM_TOKEN_RE.search(sql) and not bind_params:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "rich>=13.9.0",
     "typer>=0.15.0",
     "python-dotenv>=1.0.1",
+
+    # SQL Validation
+    "sqlglot>=20.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -30,6 +30,18 @@ async def test_query_read_requires_dict_params(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_query_read_blocks_create_table(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None,
+        None,
+        {"operation": "query_read", "sql": "CREATE TABLE test (id int)", "params": {}},
+    )
+    assert not result.success
+    assert "Use query_write for mutations" in (result.error or "")
+
+
+@pytest.mark.asyncio
 async def test_query_write_parameter_tokens_require_params(tmp_path: Path) -> None:
     tool = DatabaseTool(_make_mp(tmp_path))
     result = await tool.execute(
@@ -39,6 +51,18 @@ async def test_query_write_parameter_tokens_require_params(tmp_path: Path) -> No
     )
     assert not result.success
     assert "named parameters" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_query_write_blocks_create_table(tmp_path: Path) -> None:
+    tool = DatabaseTool(_make_mp(tmp_path))
+    result = await tool.execute(
+        None,
+        None,
+        {"operation": "query_write", "sql": "CREATE TABLE users (id int)", "params": {}, "_confirmation_token": "ok"},
+    )
+    assert not result.success
+    assert "permanently blocked" in (result.error or "").lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes critical vulnerability where users could bypass SQL checks using CTEs or comments. We now use AST-based validation using `sqlglot` to recursively check for forbidden nodes.

---
*PR created automatically by Jules for task [16210695059520001947](https://jules.google.com/task/16210695059520001947) started by @Psyborgs-git*