### PR TITLE
🔒 fix: Prevent SQL injection via AST validation in DatabaseTool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Thumbs.db
 # Rust
 target/
 harness-core/target/
+*.log

--- a/harness/tools/db_tool.py
+++ b/harness/tools/db_tool.py
@@ -21,9 +21,11 @@ Supported operations (via ``params["operation"]``)
 
 from __future__ import annotations
 
-import re
 import time
 from typing import TYPE_CHECKING, Any
+
+import sqlglot
+import sqlglot.expressions as exp
 
 from harness.core.permissions import Permission
 from harness.tools.base_tool import AbstractTool, ToolResult
@@ -34,18 +36,6 @@ if TYPE_CHECKING:
 
 _MAX_ROWS = 500
 _QUERY_TIMEOUT_S = 10
-
-# Statements that are always blocked
-_PERMANENT_BLOCK_RE = re.compile(
-    r"\b(DROP\s+TABLE|DROP\s+DATABASE|TRUNCATE|ALTER\s+TABLE)\b",
-    re.IGNORECASE,
-)
-
-# Only SELECT is allowed for query_read
-_SELECT_ONLY_RE = re.compile(r"^\s*SELECT\b", re.IGNORECASE)
-
-# INSERT / UPDATE / DELETE allowed for query_write
-_WRITE_RE = re.compile(r"^\s*(INSERT|UPDATE|DELETE)\b", re.IGNORECASE)
 
 
 class DatabaseTool(AbstractTool):
@@ -96,6 +86,83 @@ class DatabaseTool(AbstractTool):
         result.metadata["duration_ms"] = int((time.time() - t0) * 1000)
         result.metadata["operation"] = operation
         return result
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    async def _get_dialect(self) -> str:
+        """Return the sqlglot dialect ('sqlite' or 'postgres') based on the active engine."""
+        engine = await self._get_engine()
+        dialect_name = getattr(getattr(engine, "dialect", None), "name", "sqlite")
+        return "postgres" if dialect_name == "postgresql" else "sqlite"
+
+    def _validate_sql_ast(
+        self, sql: str, dialect: str, allowed_types: tuple[type[exp.Expression], ...]
+    ) -> ToolResult | None:
+        """Parse and validate SQL using sqlglot AST. Returns an error ToolResult if invalid, else None."""
+        try:
+            parsed = sqlglot.parse(sql, dialect=dialect)
+        except sqlglot.errors.ParseError as e:
+            return ToolResult(
+                success=False,
+                error=f"SQL syntax error: {e}",
+            )
+
+        # Ensure there is exactly one statement to prevent chained injections (e.g. SELECT 1; DROP TABLE users;)
+        # Filter out empty statements (None) which happen with trailing semicolons
+        statements = [stmt for stmt in parsed if stmt is not None]
+        if not statements:
+            return ToolResult(success=False, error="No valid SQL statement found.")
+        if len(statements) > 1:
+            return ToolResult(
+                success=False,
+                error="Multiple statements are not allowed.",
+            )
+
+        stmt = statements[0]
+
+        # Permanently block specific DDL statements
+        # We explicitly block Drop, Alter, and Command (often Truncate)
+        for walk_result in stmt.walk():
+            # Support sqlglot versions where walk() yields (node, parent, key) or just node
+            node = walk_result[0] if isinstance(walk_result, tuple) else walk_result
+            if isinstance(node, (exp.Drop, exp.Alter, exp.Command)):
+                # Double check for Truncate just in case it parses differently
+                if isinstance(node, exp.Command) and str(node).upper().startswith("TRUNCATE"):
+                    return ToolResult(
+                        success=False,
+                        error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
+                    )
+                elif isinstance(node, (exp.Drop, exp.Alter)):
+                    return ToolResult(
+                        success=False,
+                        error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
+                    )
+            # Truncate might be parsed as exp.Command or have its own class in newer sqlglot
+            if type(node).__name__ == "Truncate":
+                return ToolResult(
+                    success=False,
+                    error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
+                )
+
+        # Check allowed types for the top-level statement
+        if not isinstance(stmt, allowed_types):
+            allowed_names = "/".join([t.__name__.upper() for t in allowed_types])
+            return ToolResult(
+                success=False,
+                error=f"Operation only accepts {allowed_names} statements. Got {type(stmt).__name__.upper()}.",
+            )
+
+        # If it's a Select (read operation), ensure no sneaky mutations exist within (e.g., CTEs doing inserts)
+        if isinstance(stmt, (exp.Select, exp.SetOperation)):
+            for walk_result in stmt.walk():
+                node = walk_result[0] if isinstance(walk_result, tuple) else walk_result
+                if isinstance(node, (exp.Insert, exp.Update, exp.Delete)):
+                    return ToolResult(
+                        success=False,
+                        error="Mutation statements (INSERT/UPDATE/DELETE) are not allowed in query_read.",
+                    )
+
+        return None
 
     # ── Operation implementations ─────────────────────────────────────────────
 
@@ -152,18 +219,13 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
-
-        if not _SELECT_ONLY_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_read only accepts SELECT statements. Use query_write for mutations.",
-            )
+        # AST Validation: allow only Select, block chained/nested mutations
+        dialect = await self._get_dialect()
+        validation_error = self._validate_sql_ast(sql, dialect, (exp.Select, exp.SetOperation))
+        if validation_error:
+            if "Operation only accepts SELECT" in validation_error.error:
+                validation_error.error = "query_read only accepts SELECT statements. Use query_write for mutations."
+            return validation_error
 
         factory = get_session_factory()
         async with factory() as session:
@@ -204,18 +266,15 @@ class DatabaseTool(AbstractTool):
         if not sql.strip():
             return ToolResult(success=False, error="'sql' parameter is required")
 
-        # Block permanently dangerous statements
-        if _PERMANENT_BLOCK_RE.search(sql):
-            return ToolResult(
-                success=False,
-                error="Query contains a permanently blocked statement (DROP/TRUNCATE/ALTER).",
-            )
-
-        if not _WRITE_RE.match(sql):
-            return ToolResult(
-                success=False,
-                error="query_write only accepts INSERT/UPDATE/DELETE statements.",
-            )
+        # AST Validation: allow Insert, Update, Delete
+        dialect = await self._get_dialect()
+        validation_error = self._validate_sql_ast(
+            sql, dialect, (exp.Insert, exp.Update, exp.Delete)
+        )
+        if validation_error:
+            if "Operation only accepts INSERT/UPDATE/DELETE" in validation_error.error:
+                validation_error.error = "query_write only accepts INSERT/UPDATE/DELETE statements."
+            return validation_error
 
         # Require confirmation unless token already provided
         if not confirmation_token:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "typer>=0.15.0",
     "python-dotenv>=1.0.1",
     "psutil>=6.0.0",
+    "sqlglot>=23.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_db_tool.py
+++ b/tests/test_db_tool.py
@@ -1,0 +1,107 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from harness.tools.db_tool import DatabaseTool
+from harness.core.main_process import MainProcess
+from harness.core.permissions import Permission
+from harness.tools.exceptions import ConfirmationRequired
+
+@pytest.fixture
+def mock_mp():
+    # Make sure we don't spec it strictly if properties are not available statically
+    mp = MagicMock()
+    mp.permissions.has.return_value = True
+    mp.tools.confirmations.create.return_value = MagicMock(token="fake_token")
+    return mp
+
+@pytest.fixture
+def db_tool(mock_mp):
+    tool = DatabaseTool(mock_mp)
+    # Mock _get_engine to return sqlite
+    mock_engine = MagicMock()
+    mock_engine.dialect.name = "sqlite"
+    tool._get_engine = AsyncMock(return_value=mock_engine)
+    return tool
+
+@pytest.mark.asyncio
+async def test_validate_sql_ast_read_only(db_tool):
+    dialect = "sqlite"
+    import sqlglot.expressions as exp
+
+    # Valid simple select
+    sql = "SELECT * FROM users"
+    assert db_tool._validate_sql_ast(sql, dialect, (exp.Select,)) is None
+
+    # Valid CTE select
+    sql = "WITH cte AS (SELECT 1 AS a) SELECT * FROM cte"
+    assert db_tool._validate_sql_ast(sql, dialect, (exp.Select,)) is None
+
+    # Invalid read: contains multiple statements (chained injection)
+    sql = "SELECT 1; DROP TABLE users"
+    res = db_tool._validate_sql_ast(sql, dialect, (exp.Select,))
+    assert res is not None
+    assert res.success is False
+    assert "Multiple statements" in res.error
+
+    # Invalid read: mutation inside CTE
+    sql = "WITH inserted AS (INSERT INTO users (name) VALUES ('test') RETURNING id) SELECT * FROM inserted"
+    res = db_tool._validate_sql_ast(sql, dialect, (exp.Select,))
+    assert res is not None
+    assert res.success is False
+    assert "Mutation statements" in res.error
+
+    # Invalid read: not a select
+    sql = "UPDATE users SET name = 'test'"
+    res = db_tool._validate_sql_ast(sql, dialect, (exp.Select,))
+    assert res is not None
+    assert res.success is False
+    assert "Operation only accepts SELECT" in res.error
+
+@pytest.mark.asyncio
+async def test_validate_sql_ast_write(db_tool):
+    dialect = "sqlite"
+    import sqlglot.expressions as exp
+    allowed = (exp.Insert, exp.Update, exp.Delete)
+
+    # Valid write
+    sql = "INSERT INTO users (name) VALUES ('test')"
+    assert db_tool._validate_sql_ast(sql, dialect, allowed) is None
+
+    sql = "UPDATE users SET name = 'test2' WHERE id = 1"
+    assert db_tool._validate_sql_ast(sql, dialect, allowed) is None
+
+    sql = "DELETE FROM users WHERE id = 1"
+    assert db_tool._validate_sql_ast(sql, dialect, allowed) is None
+
+    # Invalid write: permanently blocked DDL
+    sql = "DROP TABLE users"
+    res = db_tool._validate_sql_ast(sql, dialect, allowed)
+    assert res is not None
+    assert res.success is False
+    assert "DROP/TRUNCATE/ALTER" in res.error
+
+    sql = "ALTER TABLE users ADD COLUMN age INT"
+    res = db_tool._validate_sql_ast(sql, dialect, allowed)
+    assert res is not None
+    assert res.success is False
+    assert "DROP/TRUNCATE/ALTER" in res.error
+
+    # Invalid write: chained
+    sql = "INSERT INTO users (name) VALUES ('test'); DROP TABLE users"
+    res = db_tool._validate_sql_ast(sql, dialect, allowed)
+    assert res is not None
+    assert res.success is False
+    assert "Multiple statements" in res.error
+
+@pytest.mark.asyncio
+async def test_validate_sql_ast_read_set_operations(db_tool):
+    dialect = "sqlite"
+    import sqlglot.expressions as exp
+
+    # Valid UNION
+    sql = "SELECT 1 UNION SELECT 2"
+    assert db_tool._validate_sql_ast(sql, dialect, (exp.Select, exp.SetOperation)) is None
+
+    # Valid INTERSECT
+    sql = "SELECT 1 INTERSECT SELECT 2"
+    assert db_tool._validate_sql_ast(sql, dialect, (exp.Select, exp.SetOperation)) is None


### PR DESCRIPTION
🎯 **What:** Replaced regex-based SQL query validation with `sqlglot` AST parsing in `DatabaseTool`.
⚠️ **Risk:** The previous regex validation only checked the beginning of strings, making the system vulnerable to chained SQL injections (`SELECT 1; DROP TABLE users`) and hidden mutations within common table expressions (CTEs).
🛡️ **Solution:** Integrated `sqlglot` to parse the query string. The new validator ensures exactly one statement is provided, explicitly blocks permanently banned DDL commands (`DROP`, `ALTER`, `TRUNCATE`), and enforces that read queries strictly use `SELECT` or `SetOperation` (e.g., `UNION`) while checking that no mutation nodes exist within the AST. Write queries are similarly restricted to `INSERT`, `UPDATE`, and `DELETE` nodes. Added unit tests for these validation checks.

---
*PR created automatically by Jules for task [5001274201145498585](https://jules.google.com/task/5001274201145498585) started by @Psyborgs-git*