### PR TITLE
🧹 Refactor inject_harness_vars to use a configuration object

### DIFF
--- a/harness/server/injector.py
+++ b/harness/server/injector.py
@@ -6,16 +6,22 @@ import json
 import re
 from typing import Any
 
+from pydantic import BaseModel
+
 _HEAD_RE = re.compile(r"(<head[^>]*>)", re.IGNORECASE)
+
+
+class HarnessConfigInjector(BaseModel):
+    component_id: str
+    api_base: str
+    ws_base: str
+    initial_state: dict[str, Any]
+    permissions: list[str]
 
 
 def inject_harness_vars(
     html: str,
-    component_id: str,
-    api_base: str,
-    ws_base: str,
-    initial_state: dict[str, Any],
-    permissions: list[str],
+    config: HarnessConfigInjector,
 ) -> str:
     """
     Inject ``window.__HARNESS__`` into the <head> of an HTML document.
@@ -23,11 +29,11 @@ def inject_harness_vars(
     If no <head> tag exists the script is prepended to the document.
     """
     payload = {
-        "COMPONENT_ID": component_id,
-        "API_URL": f"{api_base}/api/{component_id}",
-        "WS_URL": f"{ws_base}/ws/{component_id}",
-        "INITIAL_STATE": initial_state,
-        "PERMISSIONS": permissions,
+        "COMPONENT_ID": config.component_id,
+        "API_URL": f"{config.api_base}/api/{config.component_id}",
+        "WS_URL": f"{config.ws_base}/ws/{config.component_id}",
+        "INITIAL_STATE": config.initial_state,
+        "PERMISSIONS": config.permissions,
     }
     script = (
         "<script>\n"

--- a/harness/server/routes/proxy.py
+++ b/harness/server/routes/proxy.py
@@ -15,7 +15,7 @@ import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, Response
 
-from harness.server.injector import inject_harness_vars
+from harness.server.injector import HarnessConfigInjector, inject_harness_vars
 
 router = APIRouter()
 
@@ -95,11 +95,13 @@ def _inject_html_from_dist(
     ws_base = f"ws://{settings.harness_host}:{settings.harness_port}"
     html = inject_harness_vars(
         html=raw_html,
-        component_id=component_id,
-        api_base=api_base,
-        ws_base=ws_base,
-        initial_state=initial_state,
-        permissions=permissions,
+        config=HarnessConfigInjector(
+            component_id=component_id,
+            api_base=api_base,
+            ws_base=ws_base,
+            initial_state=initial_state,
+            permissions=permissions,
+        ),
     )
     return HTMLResponse(content=html, status_code=200)
 
@@ -145,11 +147,13 @@ async def serve_root_ui(request: Request, path: str = "") -> Response:
 
     html = inject_harness_vars(
         html=resp.text,
-        component_id="root",
-        api_base=api_base,
-        ws_base=ws_base,
-        initial_state={},
-        permissions=[],
+        config=HarnessConfigInjector(
+            component_id="root",
+            api_base=api_base,
+            ws_base=ws_base,
+            initial_state={},
+            permissions=[],
+        ),
     )
     return HTMLResponse(content=html, status_code=resp.status_code)
 
@@ -248,10 +252,12 @@ async def serve_component_ui(
 
     html = inject_harness_vars(
         html=resp.text,
-        component_id=component_id,
-        api_base=api_base,
-        ws_base=ws_base,
-        initial_state=comp.state,
-        permissions=perms,
+        config=HarnessConfigInjector(
+            component_id=component_id,
+            api_base=api_base,
+            ws_base=ws_base,
+            initial_state=comp.state,
+            permissions=perms,
+        ),
     )
     return HTMLResponse(content=html, status_code=resp.status_code)

--- a/tests/test_injector.py
+++ b/tests/test_injector.py
@@ -1,17 +1,19 @@
 """Unit tests for the HTML injector."""
 
-from harness.server.injector import inject_harness_vars
+from harness.server.injector import HarnessConfigInjector, inject_harness_vars
 
 
 def test_injects_into_head():
     html = "<html><head><title>Test</title></head><body></body></html>"
     result = inject_harness_vars(
         html=html,
-        component_id="comp_abc",
-        api_base="http://localhost:8000",
-        ws_base="ws://localhost:8000",
-        initial_state={"count": 0},
-        permissions=["ui.resize"],
+        config=HarnessConfigInjector(
+            component_id="comp_abc",
+            api_base="http://localhost:8000",
+            ws_base="ws://localhost:8000",
+            initial_state={"count": 0},
+            permissions=["ui.resize"],
+        ),
     )
     assert "window.__HARNESS__" in result
     assert '"COMPONENT_ID": "comp_abc"' in result
@@ -27,10 +29,12 @@ def test_injects_without_head():
     html = "<html><body>No head</body></html>"
     result = inject_harness_vars(
         html=html,
-        component_id="comp_xyz",
-        api_base="http://localhost:8000",
-        ws_base="ws://localhost:8000",
-        initial_state={},
-        permissions=[],
+        config=HarnessConfigInjector(
+            component_id="comp_xyz",
+            api_base="http://localhost:8000",
+            ws_base="ws://localhost:8000",
+            initial_state={},
+            permissions=[],
+        ),
     )
     assert "window.__HARNESS__" in result


### PR DESCRIPTION
🎯 **What:** Refactored `inject_harness_vars` to use a `HarnessConfigInjector` Pydantic model instead of five separate arguments.
💡 **Why:** Reduces parameter count on `inject_harness_vars` from 6 to 2, significantly improving readability and creating a cleaner structure that easily supports future extensions.
✅ **Verification:** Ran `pytest tests/test_injector.py`, `ruff check`, and `mypy` successfully to ensure behavior remains identical and safely typed.
✨ **Result:** Cleaner signature and call sites for HTML injection.

---
*PR created automatically by Jules for task [1654735546764995241](https://jules.google.com/task/1654735546764995241) started by @Psyborgs-git*