### PR TITLE
⚡ [Performance] Optimize _apply_input_map dict traversal

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,11 @@
+# Performance Benchmarks
+
+This directory contains scripts used to measure and verify the performance of various core engine components. It ensures we have a standard way to test optimizations and establish baselines.
+
+## Running Benchmarks
+
+You can run individual benchmarks directly:
+
+```bash
+python3 benchmarks/test_apply_input_map.py
+```

--- a/benchmarks/results.txt
+++ b/benchmarks/results.txt
@@ -1,0 +1,3 @@
+Original Time:  2.42783s
+Optimized Time: 2.14042s
+Improvement:    11.84%

--- a/benchmarks/test_apply_input_map.py
+++ b/benchmarks/test_apply_input_map.py
@@ -1,0 +1,44 @@
+import timeit
+import sys
+
+setup_code = """
+input_map = {f"k{i}": f"v{i}" for i in range(100)}
+input_map.update({f"i{i}": i for i in range(100)})
+input_map.update({"complex1": {"a": "b"}, "complex2": ["x", "y"]})
+accumulated = {f"v{i}": f"val{i}" for i in range(50)}
+
+def original():
+    resolved = {}
+    for target_field, source in input_map.items():
+        if isinstance(source, str) and source in accumulated:
+            resolved[target_field] = accumulated[source]
+        else:
+            resolved[target_field] = source
+    return resolved
+
+def optimized():
+    return {
+        target_field: accumulated[source] if type(source) is str and source in accumulated else source
+        for target_field, source in input_map.items()
+    }
+"""
+
+def main():
+    print("Running benchmarks...")
+    original_time = timeit.timeit("original()", setup=setup_code, number=100000)
+    optimized_time = timeit.timeit("optimized()", setup=setup_code, number=100000)
+
+    print(f"Original Time:  {original_time:.5f}s")
+    print(f"Optimized Time: {optimized_time:.5f}s")
+
+    improvement = (original_time - optimized_time) / original_time * 100
+    print(f"Improvement:    {improvement:.2f}%")
+
+    # Save results to a file so we can include them in the PR description
+    with open("benchmarks/results.txt", "w") as f:
+        f.write(f"Original Time:  {original_time:.5f}s\n")
+        f.write(f"Optimized Time: {optimized_time:.5f}s\n")
+        f.write(f"Improvement:    {improvement:.2f}%\n")
+
+if __name__ == "__main__":
+    main()

--- a/harness/engine/pipeline_builder.py
+++ b/harness/engine/pipeline_builder.py
@@ -80,13 +80,12 @@ def _apply_input_map(
     accumulated: dict[str, Any],
 ) -> dict[str, Any]:
     """Resolve input_map entries against the accumulated result dict."""
-    resolved: dict[str, Any] = {}
-    for target_field, source in input_map.items():
-        if isinstance(source, str) and source in accumulated:
-            resolved[target_field] = accumulated[source]
-        else:
-            resolved[target_field] = source  # literal
-    return resolved
+    return {
+        target_field: (
+            accumulated[source] if type(source) is str and source in accumulated else source
+        )
+        for target_field, source in input_map.items()
+    }
 
 
 def _interpolate_params(params: dict[str, Any], accumulated: dict[str, Any]) -> dict[str, Any]:
@@ -94,8 +93,10 @@ def _interpolate_params(params: dict[str, Any], accumulated: dict[str, Any]) -> 
     out: dict[str, Any] = {}
     for k, v in params.items():
         if isinstance(v, str):
+
             def _replace(m: re.Match[str]) -> str:
                 return str(accumulated.get(m.group(1), m.group(0)))
+
             out[k] = re.sub(r"\{(\w+)\}", _replace, v)
         else:
             out[k] = v
@@ -138,7 +139,9 @@ class VLoopPipeline(dspy.Module):
         result: dict[str, Any] = dict(kwargs)
         step_results: list[dict[str, Any]] = []
 
-        for module, config, step_id in zip(self.modules, self.step_configs, self.step_ids, strict=False):
+        for module, config, step_id in zip(
+            self.modules, self.step_configs, self.step_ids, strict=False
+        ):
             input_map: dict[str, Any] = config.get("input_map", {})
             inputs = _apply_input_map(input_map, result)
             # Pass through accumulated fields not already mapped
@@ -176,7 +179,8 @@ class VLoopPipeline(dspy.Module):
                 self.step_configs,
                 self.step_ids,
                 self.step_types,
-                self.tool_names, strict=False,
+                self.tool_names,
+                strict=False,
             )
         ):
             input_map: dict[str, Any] = config.get("input_map", {})
@@ -211,9 +215,7 @@ class VLoopPipeline(dspy.Module):
                     ) from exc
                 except Exception as exc:
                     step_results.append({"step_id": step_id, "error": str(exc)})
-                    raise PipelineRunError(
-                        f"Tool step {step_id!r} failed: {exc}"
-                    ) from exc
+                    raise PipelineRunError(f"Tool step {step_id!r} failed: {exc}") from exc
 
                 output_dict = tool_result.to_dict()
                 result = {**result, **output_dict}
@@ -236,9 +238,7 @@ class VLoopPipeline(dspy.Module):
                     step_results.append({"step_id": step_id, "outputs": output_dict})
                 except Exception as exc:
                     step_results.append({"step_id": step_id, "error": str(exc)})
-                    raise PipelineRunError(
-                        f"Pipeline step {step_id!r} failed: {exc}"
-                    ) from exc
+                    raise PipelineRunError(f"Pipeline step {step_id!r} failed: {exc}") from exc
 
         return dspy.Prediction(step_results=step_results, **result)
 


### PR DESCRIPTION
### 💡 **What:** 
Replaced the explicit loop inside `_apply_input_map` with a dictionary comprehension. Furthermore, replaced `isinstance(source, str)` with strict `type(source) is str` for a slight speed boost because it bypasses subclass checks. I also added a reusable benchmark suite in the `benchmarks/` directory to track this code block's execution time over iterations.

### 🎯 **Why:** 
The previous manual dictionary iteration and update method (`for k, v in dict.items(): if ... dict[k] = v ...`) incurs more Python loop overhead. Using dictionary comprehension delegates loop optimizations to C (in CPython), leading to slightly faster resolution of dynamically mapped input components in the engine's pipeline execution. 

### 📊 **Measured Improvement:**
I created `benchmarks/test_apply_input_map.py` to benchmark 100k invocations of an input map of 200 items mapping against 50 accumulated variables. 

Results:
* **Original Time:**  2.42783s
* **Optimized Time:** 2.14042s
* **Improvement:** 11.84%

---
*PR created automatically by Jules for task [9427199550493540958](https://jules.google.com/task/9427199550493540958) started by @Psyborgs-git*