### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unauthenticated admin registration endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Overly permissive CORS configuration (`allow_origins=["*"]`) allowed cross-origin requests from any domain, creating a security vulnerability for CSRF and data leakage.
 **Learning:** Default FastAPI examples or quick setups often use wildcard CORS, which mistakenly gets deployed. FastApi allows setting string limits, but often applications use comma-separated env vars which requires manual splitting.
 **Prevention:** Strictly define `ALLOWED_ORIGINS` dynamically through an environment variable and load it securely through pydantic settings, instead of using wildcards.
+## 2026-06-12 - [Fix unauthenticated admin registration endpoint]
+**Vulnerability:** The `/register` endpoint was unauthenticated, allowing any user to create new user accounts (which function as admin in this application), due to missing `require_admin` dependency.
+**Learning:** In initial application setup, it's common to leave administrative creation endpoints open for convenience, but they must be closed or placed behind proper setup guards to prevent takeover in production.
+**Prevention:** Ensure that admin registration endpoints correctly utilize `current_user: User = Depends(require_admin)` or require an invite code for initialization.

--- a/harness/server/routes/auth_routes.py
+++ b/harness/server/routes/auth_routes.py
@@ -51,12 +51,12 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
 
 
 @router.post("/register", response_model=User)
-async def register(user_create: UserCreate):
+async def register(
+    user_create: UserCreate,
+    current_user: User = Depends(require_admin),
+):
     """Register a new user (admin only)."""
     auth_manager = get_auth_manager()
-    
-    # Check if current user is admin (simplified - in production, use proper auth)
-    # For now, allow registration without auth for initial setup
     
     try:
         user = auth_manager.create_user(user_create)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `/register` endpoint was unauthenticated, allowing any user to create an account, which meant anyone could provision an admin account.
🎯 **Impact:** Complete system takeover due to lack of access control on account provisioning.
🔧 **Fix:** Added `current_user: User = Depends(require_admin)` to the `/register` endpoint signature, properly securing the endpoint using FastAPI's dependency injection system and removing the unsafe bypass comments.
✅ **Verification:** Verified by running the test suite (`pytest tests/`) to ensure no functionality is broken and all tests continue to pass. The updated `.jules/sentinel.md` file tracks this finding.

---
*PR created automatically by Jules for task [14196085086831995507](https://jules.google.com/task/14196085086831995507) started by @Psyborgs-git*