### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers to FastAPI responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Add Security Headers to FastAPI
+**Vulnerability:** Missing Security Headers
+**Learning:** FastAPI does not include security headers by default. This leaves the API vulnerable to Clickjacking, XSS, and MIME-sniffing.
+**Prevention:** Add a middleware to automatically inject X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, and Content-Security-Policy headers.

--- a/control-plane/cp/http_api.py
+++ b/control-plane/cp/http_api.py
@@ -1,8 +1,26 @@
 """CP HTTP/WebSocket API scaffold."""
 
 from fastapi import FastAPI
+from fastapi.responses import Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
 
 app = FastAPI(title="VLoop Control Plane")
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Middleware to add security headers to all responses."""
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"
+        return response
+
+
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 @app.get("/health")

--- a/control-plane/tests/test_http_api.py
+++ b/control-plane/tests/test_http_api.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from cp.http_api import app
+
+client = TestClient(app)
+
+def test_health_endpoint_and_security_headers():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "scaffold"}
+
+    # Check security headers
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    assert response.headers["Strict-Transport-Security"] == "max-age=31536000; includeSubDomains"
+    assert response.headers["Content-Security-Policy"] == "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://fastapi.tiangolo.com"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The control plane API lacked standard HTTP security headers (like HSTS, X-Frame-Options, and CSP) which makes it vulnerable to attacks such as Clickjacking, MIME-sniffing, and certain types of XSS.
🎯 Impact: Attackers could potentially embed the API inside a malicious iframe or trick the browser into executing scripts.
🔧 Fix: Implemented `SecurityHeadersMiddleware` in FastAPI to automatically inject robust default security headers to all HTTP responses, while maintaining compatibility with FastAPI's auto-generated docs (`/docs`).
✅ Verification: Ran `ruff check` and `mypy` statically. Successfully executed the new unit test via `pytest tests/test_http_api.py` validating that the `/health` endpoint indeed attaches the correct response headers.

---
*PR created automatically by Jules for task [8064684921300943727](https://jules.google.com/task/8064684921300943727) started by @Psyborgs-git*