### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing security headers to HTTP shell

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing Defense-in-Depth Headers in Raw HTTP Shell
+**Vulnerability:** The HTTP shell powered by `http.server.BaseHTTPRequestHandler` was responding to frontend and API requests without basic security headers, missing protections against XSS, clickjacking, MIME-sniffing, and lacking HSTS and CSP constraints.
+**Learning:** Raw HTTP frameworks in standard libraries (unlike modern web frameworks like FastAPI) do not include basic defense-in-depth headers by default, requiring explicit injection for all response types.
+**Prevention:** Ensure explicit wrapper/middleware methods exist to globally apply security headers when rolling custom HTTP servers or interacting directly with low-level server handlers.

--- a/control-plane/cp/http_api.py
+++ b/control-plane/cp/http_api.py
@@ -433,6 +433,14 @@ def _handler_factory(runtime: Any):
                 "internal control-plane error",
             )
 
+        def _send_security_headers(self) -> None:
+            """Injects Defense-in-Depth security headers."""
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("X-XSS-Protection", "1; mode=block")
+            self.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+            self.send_header("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
+
         def _write_json(
             self,
             payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -443,6 +451,7 @@ def _handler_factory(runtime: Any):
             self.send_response(status)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -468,6 +477,7 @@ def _handler_factory(runtime: Any):
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -483,6 +493,7 @@ def _handler_factory(runtime: Any):
             if encoding:
                 self.send_header("Content-Encoding", encoding)
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The raw HTTP server (`http.server.BaseHTTPRequestHandler`) was serving API responses and static assets without defense-in-depth security headers, leaving the application vulnerable to clickjacking, MIME-sniffing, XSS, and lacking HSTS and CSP constraints.
🎯 Impact: Attackers could potentially exploit missing headers to trick browsers into executing malicious scripts, sniffing MIME types, or clickjacking the application if deployed broadly.
🔧 Fix: Added a `_send_security_headers` method to manually inject the missing standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, `Content-Security-Policy`) into all HTML, JSON, and file responses.
✅ Verification: Ran unit tests (none available initially), syntax validation with `python -m py_compile`, `ruff check`, and `mypy` to verify the new method injection did not cause regressions. Additionally created an entry in `.jules/sentinel.md` outlining the findings.

---
*PR created automatically by Jules for task [1893735575657383653](https://jules.google.com/task/1893735575657383653) started by @Psyborgs-git*