### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense-in-Depth security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-25 - Missing security headers for API responses
+**Vulnerability:** Control-plane HTTP responses lacked basic Defense-in-Depth security headers (CSP, HSTS, X-Frame-Options, XSS-Protection).
+**Learning:** Python-based HTTP services need these injected explicitly in their request handlers.
+**Prevention:** Implement `_send_security_headers()` for any base `BaseHTTPRequestHandler` responses.

--- a/control-plane/cp/http_api.py
+++ b/control-plane/cp/http_api.py
@@ -433,6 +433,13 @@ def _handler_factory(runtime: Any):
                 "internal control-plane error",
             )
 
+        def _send_security_headers(self) -> None:
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("X-XSS-Protection", "1; mode=block")
+            self.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+            self.send_header("Content-Security-Policy", "default-src 'self'")
+
         def _write_json(
             self,
             payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -443,6 +450,7 @@ def _handler_factory(runtime: Any):
             self.send_response(status)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -468,6 +476,7 @@ def _handler_factory(runtime: Any):
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
@@ -483,6 +492,7 @@ def _handler_factory(runtime: Any):
             if encoding:
                 self.send_header("Content-Encoding", encoding)
             self.send_header("Cache-Control", "no-store")
+            self._send_security_headers()
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Python Control-Plane HTTP shell responses were missing basic Defense-in-Depth HTTP security headers (such as `Content-Security-Policy` and `Strict-Transport-Security`).
🎯 **Impact:** Exposes the control-plane interface to potential exploitation via XSS, clickjacking, MIME-type sniffing, or unencrypted local access downgrades, particularly in environments without a secure reverse proxy.
🔧 **Fix:** Added a `_send_security_headers` method to `ControlPlaneHandler` inside `control-plane/cp/http_api.py`. Invoked this method across all response endpoints (`_write_json`, `_write_html`, `_write_file`) prior to `end_headers()`.
✅ **Verification:** Verified by running the test suite (`pytest`), linting (`ruff check`), and type-checking (`mypy --explicit-package-bases .`) to ensure no broken routing or execution logic. Added a new entry to the Sentinel journal for future reference.

---
*PR created automatically by Jules for task [2755047566236652978](https://jules.google.com/task/2755047566236652978) started by @Psyborgs-git*