### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense-in-Depth security headers to HTTP shell

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-26 - Control Plane HTTP Security Headers
+**Vulnerability:** The Python Control Plane HTTP shell lacked Defense-in-Depth security headers (CSP, X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security), exposing the interface to various web-based attacks (XSS, Clickjacking).
+**Learning:** Since the HTTP shell uses `http.server.BaseHTTPRequestHandler` instead of FastAPI, security headers must be manually injected into all HTTP responses via a custom method rather than relying on middleware.
+**Prevention:** Always implement an explicit header injection method (e.g., `_send_security_headers()`) for standard library HTTP servers and call it before `end_headers()` in all write methods (`_write_json`, `_write_html`, `_write_file`).

--- a/control-plane/cp/http_api.py
+++ b/control-plane/cp/http_api.py
@@ -433,6 +433,13 @@ def _handler_factory(runtime: Any):
                 "internal control-plane error",
             )
 
+        def _send_security_headers(self) -> None:
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("X-XSS-Protection", "1; mode=block")
+            self.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+            self.send_header("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
+
         def _write_json(
             self,
             payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -444,6 +451,7 @@ def _handler_factory(runtime: Any):
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
             self.send_header("Content-Length", str(len(body)))
+            self._send_security_headers()
             self.end_headers()
             self.wfile.write(body)
 
@@ -469,6 +477,7 @@ def _handler_factory(runtime: Any):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Cache-Control", "no-store")
             self.send_header("Content-Length", str(len(body)))
+            self._send_security_headers()
             self.end_headers()
             self.wfile.write(body)
 
@@ -484,6 +493,7 @@ def _handler_factory(runtime: Any):
                 self.send_header("Content-Encoding", encoding)
             self.send_header("Cache-Control", "no-store")
             self.send_header("Content-Length", str(len(body)))
+            self._send_security_headers()
             self.end_headers()
             self.wfile.write(body)
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Python Control Plane HTTP shell (`http_api.py`) lacked standard security headers, exposing the user interface to potential XSS, Clickjacking, and framing vulnerabilities.
🎯 Impact: An attacker could potentially frame the control plane shell on a malicious site, spoof requests, or inject scripts in browsers if other vulnerabilities were found (defense in depth failure).
🔧 Fix: Added a `_send_security_headers()` method to manually inject `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, and `Content-Security-Policy` into every JSON, HTML, and static file response.
✅ Verification: Ran `pytest` and verified with test scripts that the HTTP shell returns these headers upon request.
📝 Journal Entry: Added a new learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12462707750581143455](https://jules.google.com/task/12462707750581143455) started by @Psyborgs-git*