### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing defense-in-depth security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-27 - Add missing defense-in-depth security headers
+**Vulnerability:** The HTTP shell uses `http.server.BaseHTTPRequestHandler` which does not inject typical framework-provided security headers (e.g., CSP, X-Frame-Options) by default.
+**Learning:** When using low-level handlers like `BaseHTTPRequestHandler`, defense-in-depth security headers must be manually injected into all HTTP responses.
+**Prevention:** Always ensure a centralized method injects headers like `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, and `Content-Security-Policy` when building custom HTTP handlers.

--- a/control-plane/cp/http_responders.py
+++ b/control-plane/cp/http_responders.py
@@ -9,6 +9,15 @@ from pathlib import Path
 from typing import Any
 
 
+def _send_security_headers(handler: Any) -> None:
+    """Inject defense-in-depth security headers into the response."""
+    handler.send_header("X-Content-Type-Options", "nosniff")
+    handler.send_header("X-Frame-Options", "DENY")
+    handler.send_header("X-XSS-Protection", "1; mode=block")
+    handler.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+    handler.send_header("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:")
+
+
 def write_json(
     handler: Any,
     payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -20,6 +29,7 @@ def write_json(
     handler.send_header("Content-Type", "application/json; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -47,6 +57,7 @@ def write_html(handler: Any, html: str) -> None:
     handler.send_header("Content-Type", "text/html; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -63,5 +74,6 @@ def write_file(handler: Any, path: Path) -> None:
         handler.send_header("Content-Encoding", encoding)
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The HTTP shell in `control-plane/cp/http_responders.py` leverages `http.server.BaseHTTPRequestHandler`, which by default does not include any security headers.
🎯 Impact: Without explicit security headers, the application is more susceptible to MIME sniffing, clickjacking, XSS, and lacking a strong HTTPS enforcement and content security policy constraints.
🔧 Fix: Added a new internal function `_send_security_headers()` that injects `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`, `Strict-Transport-Security`, and a basic `Content-Security-Policy` allowing inline scripts and styles. This is called across `write_json`, `write_html`, and `write_file`. Added `.jules/sentinel.md` entry.
✅ Verification: Ran `pytest` in `control-plane/`, `npm run build` in `src/`, and `cargo check` in `kernel/`. They passed successfully. Read and verified `control-plane/cp/http_responders.py`.

---
*PR created automatically by Jules for task [1020643572276640342](https://jules.google.com/task/1020643572276640342) started by @Psyborgs-git*