### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense-in-Depth Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-28 - Missing Security Headers in Python HTTP Handlers
+**Vulnerability:** The `control-plane` HTTP server implemented directly on `http.server.BaseHTTPRequestHandler` was missing Defense-in-Depth security headers (CSP, X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security), exposing it to basic web vulnerabilities like framing and MIME-sniffing.
+**Learning:** When using low-level HTTP servers (like `BaseHTTPRequestHandler`) rather than full frameworks like FastAPI or Django, security headers must be injected manually into every response. Additionally, the CSP must allow `'unsafe-inline'` for styles and scripts to not break Vite setups and fallback shell HTML.
+**Prevention:** Standardize a responder wrapper or injection function (e.g., `_send_security_headers`) that gets called before `handler.end_headers()` in all custom HTTP response generators.

--- a/control-plane/cp/http_responders.py
+++ b/control-plane/cp/http_responders.py
@@ -9,6 +9,15 @@ from pathlib import Path
 from typing import Any
 
 
+def _send_security_headers(handler: Any) -> None:
+    handler.send_header("X-Content-Type-Options", "nosniff")
+    handler.send_header("X-Frame-Options", "DENY")
+    handler.send_header("X-XSS-Protection", "1; mode=block")
+    handler.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+    # Allow 'unsafe-inline' for both scripts and styles to support Vite's setup and Python's fallback HTML shells.
+    handler.send_header("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http: https:;")
+
+
 def write_json(
     handler: Any,
     payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -20,6 +29,7 @@ def write_json(
     handler.send_header("Content-Type", "application/json; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -47,6 +57,7 @@ def write_html(handler: Any, html: str) -> None:
     handler.send_header("Content-Type", "text/html; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -63,5 +74,6 @@ def write_file(handler: Any, path: Path) -> None:
         handler.send_header("Content-Encoding", encoding)
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)


### PR DESCRIPTION
Adds Defense-in-Depth security headers to the Python control-plane HTTP responders.

🚨 Severity: MEDIUM
💡 Vulnerability: The control-plane HTTP server implemented directly on `http.server.BaseHTTPRequestHandler` was missing Defense-in-Depth security headers (CSP, X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security), exposing it to basic web vulnerabilities like framing and MIME-sniffing.
🎯 Impact: Attackers could potentially exploit the lack of headers to embed the server in frames (Clickjacking), sniff MIME types incorrectly, or potentially find ways to exploit XSS if content is rendered unexpectedly.
🔧 Fix: A new `_send_security_headers` function was created and called in all response methods within `control-plane/cp/http_responders.py`. It injects standard security headers while safely configuring the CSP to allow `'unsafe-inline'` for styles and scripts to not break existing Vite setups or Python fallback shell HTML.
✅ Verification: Ran `ruff check` and `mypy` locally, and the implementation correctly integrates with standard `BaseHTTPRequestHandler` structure.

---
*PR created automatically by Jules for task [11435271014408750687](https://jules.google.com/task/11435271014408750687) started by @Psyborgs-git*