### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense-in-Depth security headers to HTTP responders

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - [Defense-in-Depth] HTTP Responders Missing Security Headers
+**Vulnerability:** The HTTP responders in `control-plane/cp/http_responders.py` were missing standard Defense-in-Depth security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection). This increases the attack surface for vulnerabilities like XSS, Clickjacking, and MIME-sniffing.
+**Learning:** Due to the custom `http.server.BaseHTTPRequestHandler` implementation used by the control-plane fallback HTTP shell, standard middleware-based header injection wasn't present. The Vite React frontend requires specific CSP directives (`unsafe-inline`, `ws:`, `wss:`) for hot-reloading and dynamic script evaluation.
+**Prevention:** Always ensure that custom HTTP server implementations explicitly set Defense-in-Depth security headers on all responses, tailored to the specific needs of the frontend architecture.

--- a/control-plane/cp/http_responders.py
+++ b/control-plane/cp/http_responders.py
@@ -9,6 +9,21 @@ from pathlib import Path
 from typing import Any
 
 
+def _send_security_headers(handler: Any) -> None:
+    handler.send_header("X-Content-Type-Options", "nosniff")
+    handler.send_header("X-Frame-Options", "DENY")
+    handler.send_header("X-XSS-Protection", "1; mode=block")
+    handler.send_header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+    handler.send_header(
+        "Content-Security-Policy",
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "connect-src 'self' ws: wss:; "
+        "img-src 'self' data:; "
+        "font-src 'self' data:;"
+    )
+
 def write_json(
     handler: Any,
     payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -20,6 +35,7 @@ def write_json(
     handler.send_header("Content-Type", "application/json; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -47,6 +63,7 @@ def write_html(handler: Any, html: str) -> None:
     handler.send_header("Content-Type", "text/html; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)
 
@@ -63,5 +80,6 @@ def write_file(handler: Any, path: Path) -> None:
         handler.send_header("Content-Encoding", encoding)
     handler.send_header("Cache-Control", "no-store")
     handler.send_header("Content-Length", str(len(body)))
+    _send_security_headers(handler)
     handler.end_headers()
     handler.wfile.write(body)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The HTTP responders in `control-plane/cp/http_responders.py` were missing standard Defense-in-Depth security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection).
🎯 **Impact:** Without these headers, the HTTP shell is more vulnerable to XSS, Clickjacking, and MIME-sniffing attacks.
🔧 **Fix:** Added `_send_security_headers` to inject these headers into all HTTP responses. The CSP uses `'unsafe-inline'` and `'connect-src' ws: wss:` for React frontend compatibility.
✅ **Verification:** Verified with `pytest` and `ruff`. Ensure no regressions are introduced in the control plane HTTP shell.

---
*PR created automatically by Jules for task [5231464068495179933](https://jules.google.com/task/5231464068495179933) started by @Psyborgs-git*