### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense-in-Depth Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing Defense-in-Depth Headers in Control Plane HTTP Server
+**Vulnerability:** The Python Control Plane HTTP Server (`http_handler.py` / `http_responders.py`) was omitting security headers (like Content-Security-Policy, X-Frame-Options, X-Content-Type-Options) in its responses, leading to an increased risk of XSS, Clickjacking, and MIME-sniffing vulnerabilities.
+**Learning:** Security headers are easily overlooked when using a low-level HTTP server (`http.server.BaseHTTPRequestHandler`) instead of a fully-featured framework like FastAPI, especially for serving static fallback shells.
+**Prevention:** Always implement a dedicated function to inject baseline defense-in-depth security headers for all response types (JSON, HTML, files) in custom HTTP server implementations.

--- a/control-plane/cp/http_responders.py
+++ b/control-plane/cp/http_responders.py
@@ -93,6 +93,15 @@ def log_internal_error(
     return redacted
 
 
+def _send_security_headers(handler: Any) -> None:
+    handler.send_header("X-Content-Type-Options", "nosniff")
+    handler.send_header("X-Frame-Options", "DENY")
+    handler.send_header(
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:;",
+    )
+
+
 def write_json(
     handler: Any,
     payload: dict[str, Any] | list[Any] | str | int | float | bool | None,
@@ -103,6 +112,7 @@ def write_json(
     handler.send_response(status)
     handler.send_header("Content-Type", "application/json; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
+    _send_security_headers(handler)
     handler.send_header("Content-Length", str(len(body)))
     handler.end_headers()
     handler.wfile.write(body)
@@ -130,6 +140,7 @@ def write_html(handler: Any, html: str) -> None:
     handler.send_response(HTTPStatus.OK)
     handler.send_header("Content-Type", "text/html; charset=utf-8")
     handler.send_header("Cache-Control", "no-store")
+    _send_security_headers(handler)
     handler.send_header("Content-Length", str(len(body)))
     handler.end_headers()
     handler.wfile.write(body)
@@ -146,6 +157,7 @@ def write_file(handler: Any, path: Path) -> None:
     if encoding:
         handler.send_header("Content-Encoding", encoding)
     handler.send_header("Cache-Control", "no-store")
+    _send_security_headers(handler)
     handler.send_header("Content-Length", str(len(body)))
     handler.end_headers()
     handler.wfile.write(body)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The control plane HTTP server (`cp/http_responders.py`) was not emitting standard security headers like Content-Security-Policy, X-Frame-Options, or X-Content-Type-Options. This made any HTML responses vulnerable to MIME-sniffing, XSS, and Clickjacking since the browser would apply less secure defaults.
🎯 Impact: If malicious content were ever served or an XSS flaw existed in the fallback HTML, attackers could exploit it without mitigation.
🔧 Fix: Implemented `_send_security_headers` that writes `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and a safe `Content-Security-Policy`. This function was injected into `write_json`, `write_html`, and `write_file` to ensure it is added to every response.
✅ Verification: Ran unit tests under `tests/test_ws_delivery_and_templates.py` and `tests/test_error_presentation.py` to ensure handlers are not negatively impacted and response formatting is maintained. Created an entry in `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [13985640455498154562](https://jules.google.com/task/13985640455498154562) started by @Psyborgs-git*